### PR TITLE
ci: remove auto-format job, add format check to tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,64 +4,7 @@ on:
   pull_request:
     branches: ["*"]
 
-permissions:
-  contents: write
-
 jobs:
-  format:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: uv sync --extra dev
-
-      - name: Run ruff formatting
-        run: uv run ruff format src/ tests/
-
-      - name: Run ruff linting with auto-fix
-        run: uv run ruff check --fix src/ tests/
-
-      - name: Re-run formatting after auto-fix
-        run: uv run ruff format src/ tests/
-
-      - name: Verify all issues are fixed
-        run: |
-          uv run ruff check src/ tests/
-          uv run ruff format --check src/ tests/
-
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit and push formatting changes
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add -A
-          git commit -m "style: auto-format code with ruff"
-          git push
-
   tests:
     runs-on: ubuntu-latest
 
@@ -80,6 +23,11 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --extra dev
+
+      - name: Check formatting (ruff)
+        run: |
+          uv run ruff format --check src/ tests/
+          uv run ruff check src/ tests/
 
       - name: Run tests
         run: uv run pytest tests/ -v


### PR DESCRIPTION
Remove the separate format job that auto-committed formatting fixes, which caused issues with GitHub Actions not re-running after the auto-merge. Instead, add format checks as a step in the tests job that will fail if code is not properly formatted.