### PR TITLE
docs: add OpenCode and GitHub Copilot CLI platform details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ DeepWork is a tool for defining and executing multi-step workflows with AI codin
 |----------|--------|----------------|---------------|
 | **Claude Code** | Full Support | Markdown | Yes (stop_hooks, pre/post) |
 | **Gemini CLI** | Full Support | TOML | No (global only) |
-| GitHub Copilot | Planned | - | - |
+| OpenCode | Planned | Markdown | No |
+| GitHub Copilot CLI | Planned | Markdown | No (tool permissions only) |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Added OpenCode to the supported platforms table with command format (Markdown) and hooks support (No)
- Updated GitHub Copilot CLI entry with command format (Markdown) and hooks support (tool permissions only)

Based on research of both platforms' documentation:
- **OpenCode**: Uses Markdown files in `.opencode/command/`, no lifecycle hooks
- **GitHub Copilot CLI**: Uses Markdown agents in `.github/agents/`, has tool permissions but no pre/post execution hooks

## Test plan
- [x] Verify table renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)