### PR TITLE
Refactor job hooks configuration structure

### DIFF
--- a/.deepwork/jobs/add_platform/job.yml
+++ b/.deepwork/jobs/add_platform/job.yml
@@ -36,19 +36,20 @@ steps:
       - cli_configuration.md
       - hooks_system.md
     dependencies: []
-    stop_hooks:
-      - prompt: |
-          Verify the research output meets ALL criteria:
-          1. Both files exist in doc/platforms/<platform>/: cli_configuration.md and hooks_system.md
-          2. Each file has a comment at the top with:
-             - Last updated date
-             - Source URL where the documentation was obtained
-          3. cli_configuration.md covers how the platform's CLI is configured
-          4. hooks_system.md covers hooks available for slash command definitions ONLY
-          5. No extraneous documentation (only these two specific topics)
-          6. Documentation is comprehensive enough to implement the platform
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the research output meets ALL criteria:
+            1. Both files exist in doc/platforms/<platform>/: cli_configuration.md and hooks_system.md
+            2. Each file has a comment at the top with:
+               - Last updated date
+               - Source URL where the documentation was obtained
+            3. cli_configuration.md covers how the platform's CLI is configured
+            4. hooks_system.md covers hooks available for slash command definitions ONLY
+            5. No extraneous documentation (only these two specific topics)
+            6. Documentation is comprehensive enough to implement the platform
 
-          If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
+            If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
 
   - id: add_capabilities
     name: "Add Hook Capabilities"
@@ -62,18 +63,19 @@ steps:
       - adapters.py
     dependencies:
       - research
-    stop_hooks:
-      - prompt: |
-          Verify the capability additions meet ALL criteria:
-          1. Any new hooks from the platform (for slash commands only) are added to src/deepwork/schemas/job_schema.py
-          2. All existing adapters in src/deepwork/adapters.py are updated with the new hook fields
-             (set to None/null if the platform doesn't support that hook)
-          3. Only hooks available on slash command definitions are added (not general CLI hooks)
-          4. job_schema.py remains valid Python with no syntax errors
-          5. adapters.py remains consistent - all adapters have the same hook fields
-          6. If no new hooks are needed, document why in a comment
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the capability additions meet ALL criteria:
+            1. Any new hooks from the platform (for slash commands only) are added to src/deepwork/schemas/job_schema.py
+            2. All existing adapters in src/deepwork/adapters.py are updated with the new hook fields
+               (set to None/null if the platform doesn't support that hook)
+            3. Only hooks available on slash command definitions are added (not general CLI hooks)
+            4. job_schema.py remains valid Python with no syntax errors
+            5. adapters.py remains consistent - all adapters have the same hook fields
+            6. If no new hooks are needed, document why in a comment
 
-          If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
+            If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
 
   - id: implement
     name: "Implement Platform Support"
@@ -93,21 +95,22 @@ steps:
     dependencies:
       - research
       - add_capabilities
-    stop_hooks:
-      - script: hooks/run_tests.sh
-      - prompt: |
-          Verify the implementation meets ALL criteria:
-          1. Platform adapter class is added to src/deepwork/adapters.py
-          2. Templates exist in src/deepwork/templates/<platform>/ with appropriate command structure
-          3. Tests exist for all new functionality
-          4. Test coverage is 100% for new code (run: uv run pytest --cov)
-          5. All tests pass
-          6. README.md is updated with:
-             - New platform listed in supported platforms
-             - Installation instructions for the platform
-             - Any platform-specific notes
+    hooks:
+      after_agent:
+        - script: hooks/run_tests.sh
+        - prompt: |
+            Verify the implementation meets ALL criteria:
+            1. Platform adapter class is added to src/deepwork/adapters.py
+            2. Templates exist in src/deepwork/templates/<platform>/ with appropriate command structure
+            3. Tests exist for all new functionality
+            4. Test coverage is 100% for new code (run: uv run pytest --cov)
+            5. All tests pass
+            6. README.md is updated with:
+               - New platform listed in supported platforms
+               - Installation instructions for the platform
+               - Any platform-specific notes
 
-          If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
+            If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
 
   - id: verify
     name: "Verify Installation"
@@ -119,14 +122,15 @@ steps:
     outputs: []
     dependencies:
       - implement
-    stop_hooks:
-      - prompt: |
-          Verify the installation meets ALL criteria:
-          1. Platform-specific directories/files are added to the deepwork repo as needed
-          2. Running `deepwork install --platform <platform>` completes without errors
-          3. Expected command files are created in the platform's command directory
-          4. Command file content matches the templates and job definitions
-          5. Established DeepWork jobs (deepwork_jobs, deepwork_policy) are installed correctly
-          6. The platform can be used alongside existing platforms without conflicts
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the installation meets ALL criteria:
+            1. Platform-specific directories/files are added to the deepwork repo as needed
+            2. Running `deepwork install --platform <platform>` completes without errors
+            3. Expected command files are created in the platform's command directory
+            4. Command file content matches the templates and job definitions
+            5. Established DeepWork jobs (deepwork_jobs, deepwork_policy) are installed correctly
+            6. The platform can be used alongside existing platforms without conflicts
 
-          If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.
+            If ALL criteria are met, include `<promise>QUALITY_COMPLETE</promise>`.

--- a/.deepwork/jobs/deepwork_jobs/job.yml
+++ b/.deepwork/jobs/deepwork_jobs/job.yml
@@ -33,20 +33,21 @@ steps:
     outputs:
       - job.yml
     dependencies: []
-    stop_hooks:
-      - prompt: |
-          Verify the job.yml output meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the job.yml output meets ALL quality criteria before completing:
 
-          1. **User Understanding**: Did you fully understand the user's workflow through interactive Q&A?
-          2. **Clear Inputs/Outputs**: Does every step have clearly defined inputs and outputs?
-          3. **Logical Dependencies**: Do step dependencies make sense and avoid circular references?
-          4. **Concise Summary**: Is the summary under 200 characters and descriptive?
-          5. **Rich Description**: Does the description provide enough context for future refinement?
-          6. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
-          7. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
+            1. **User Understanding**: Did you fully understand the user's workflow through interactive Q&A?
+            2. **Clear Inputs/Outputs**: Does every step have clearly defined inputs and outputs?
+            3. **Logical Dependencies**: Do step dependencies make sense and avoid circular references?
+            4. **Concise Summary**: Is the summary under 200 characters and descriptive?
+            5. **Rich Description**: Does the description provide enough context for future refinement?
+            6. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
+            7. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
 
   - id: implement
     name: "Implement Job Steps"
@@ -59,24 +60,25 @@ steps:
       - implementation_summary.md
     dependencies:
       - define
-    stop_hooks:
-      - prompt: |
-          Verify the implementation meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the implementation meets ALL quality criteria before completing:
 
-          1. **Directory Structure**: Is `.deepwork/jobs/[job_name]/` created correctly?
-          2. **Complete Instructions**: Are ALL step instruction files complete (not stubs or placeholders)?
-          3. **Specific & Actionable**: Are instructions tailored to each step's purpose, not generic?
-          4. **Output Examples**: Does each instruction file show what good output looks like?
-          5. **Quality Criteria**: Does each instruction file define quality criteria for its outputs?
-          6. **Sync Complete**: Has `deepwork sync` been run successfully?
-          7. **Commands Available**: Are the slash-commands generated in `.claude/commands/`?
-          8. **Summary Created**: Has `implementation_summary.md` been created?
-          9. **Policies Considered**: Have you thought about whether policies would benefit this job?
-             - If relevant policies were identified, did you explain them and offer to run `/deepwork_policy.define`?
-             - Not every job needs policies - only suggest when genuinely helpful.
+            1. **Directory Structure**: Is `.deepwork/jobs/[job_name]/` created correctly?
+            2. **Complete Instructions**: Are ALL step instruction files complete (not stubs or placeholders)?
+            3. **Specific & Actionable**: Are instructions tailored to each step's purpose, not generic?
+            4. **Output Examples**: Does each instruction file show what good output looks like?
+            5. **Quality Criteria**: Does each instruction file define quality criteria for its outputs?
+            6. **Sync Complete**: Has `deepwork sync` been run successfully?
+            7. **Commands Available**: Are the slash-commands generated in `.claude/commands/`?
+            8. **Summary Created**: Has `implementation_summary.md` been created?
+            9. **Policies Considered**: Have you thought about whether policies would benefit this job?
+               - If relevant policies were identified, did you explain them and offer to run `/deepwork_policy.define`?
+               - Not every job needs policies - only suggest when genuinely helpful.
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
 
   - id: refine
     name: "Refine Existing Job"
@@ -88,18 +90,19 @@ steps:
     outputs:
       - job.yml
     dependencies: []
-    stop_hooks:
-      - prompt: |
-          Verify the refinement meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the refinement meets ALL quality criteria before completing:
 
-          1. **Job Consistency**: Do the changes maintain overall job consistency?
-          2. **Valid Dependencies**: Are all step dependencies logically valid (no circular refs)?
-          3. **Semantic Versioning**: Was the version bumped appropriately (major/minor/patch)?
-          4. **Changelog Updated**: Is the changelog updated with a description of changes?
-          5. **User Understanding**: Does the user understand the impact of the changes?
-          6. **Breaking Changes**: Were any breaking changes clearly communicated?
-          7. **Files Updated**: Are all affected files (job.yml, step files) updated?
-          8. **Sync Complete**: Has `deepwork sync` been run to regenerate commands?
+            1. **Job Consistency**: Do the changes maintain overall job consistency?
+            2. **Valid Dependencies**: Are all step dependencies logically valid (no circular refs)?
+            3. **Semantic Versioning**: Was the version bumped appropriately (major/minor/patch)?
+            4. **Changelog Updated**: Is the changelog updated with a description of changes?
+            5. **User Understanding**: Does the user understand the impact of the changes?
+            6. **Breaking Changes**: Were any breaking changes clearly communicated?
+            7. **Files Updated**: Are all affected files (job.yml, step files) updated?
+            8. **Sync Complete**: Has `deepwork sync` been run to regenerate commands?
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.

--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -33,20 +33,21 @@ steps:
     outputs:
       - job.yml
     dependencies: []
-    stop_hooks:
-      - prompt: |
-          Verify the job.yml output meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the job.yml output meets ALL quality criteria before completing:
 
-          1. **User Understanding**: Did you fully understand the user's workflow through interactive Q&A?
-          2. **Clear Inputs/Outputs**: Does every step have clearly defined inputs and outputs?
-          3. **Logical Dependencies**: Do step dependencies make sense and avoid circular references?
-          4. **Concise Summary**: Is the summary under 200 characters and descriptive?
-          5. **Rich Description**: Does the description provide enough context for future refinement?
-          6. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
-          7. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
+            1. **User Understanding**: Did you fully understand the user's workflow through interactive Q&A?
+            2. **Clear Inputs/Outputs**: Does every step have clearly defined inputs and outputs?
+            3. **Logical Dependencies**: Do step dependencies make sense and avoid circular references?
+            4. **Concise Summary**: Is the summary under 200 characters and descriptive?
+            5. **Rich Description**: Does the description provide enough context for future refinement?
+            6. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
+            7. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
 
   - id: implement
     name: "Implement Job Steps"
@@ -59,24 +60,25 @@ steps:
       - implementation_summary.md
     dependencies:
       - define
-    stop_hooks:
-      - prompt: |
-          Verify the implementation meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the implementation meets ALL quality criteria before completing:
 
-          1. **Directory Structure**: Is `.deepwork/jobs/[job_name]/` created correctly?
-          2. **Complete Instructions**: Are ALL step instruction files complete (not stubs or placeholders)?
-          3. **Specific & Actionable**: Are instructions tailored to each step's purpose, not generic?
-          4. **Output Examples**: Does each instruction file show what good output looks like?
-          5. **Quality Criteria**: Does each instruction file define quality criteria for its outputs?
-          6. **Sync Complete**: Has `deepwork sync` been run successfully?
-          7. **Commands Available**: Are the slash-commands generated in `.claude/commands/`?
-          8. **Summary Created**: Has `implementation_summary.md` been created?
-          9. **Policies Considered**: Have you thought about whether policies would benefit this job?
-             - If relevant policies were identified, did you explain them and offer to run `/deepwork_policy.define`?
-             - Not every job needs policies - only suggest when genuinely helpful.
+            1. **Directory Structure**: Is `.deepwork/jobs/[job_name]/` created correctly?
+            2. **Complete Instructions**: Are ALL step instruction files complete (not stubs or placeholders)?
+            3. **Specific & Actionable**: Are instructions tailored to each step's purpose, not generic?
+            4. **Output Examples**: Does each instruction file show what good output looks like?
+            5. **Quality Criteria**: Does each instruction file define quality criteria for its outputs?
+            6. **Sync Complete**: Has `deepwork sync` been run successfully?
+            7. **Commands Available**: Are the slash-commands generated in `.claude/commands/`?
+            8. **Summary Created**: Has `implementation_summary.md` been created?
+            9. **Policies Considered**: Have you thought about whether policies would benefit this job?
+               - If relevant policies were identified, did you explain them and offer to run `/deepwork_policy.define`?
+               - Not every job needs policies - only suggest when genuinely helpful.
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
 
   - id: refine
     name: "Refine Existing Job"
@@ -88,18 +90,19 @@ steps:
     outputs:
       - job.yml
     dependencies: []
-    stop_hooks:
-      - prompt: |
-          Verify the refinement meets ALL quality criteria before completing:
+    hooks:
+      after_agent:
+        - prompt: |
+            Verify the refinement meets ALL quality criteria before completing:
 
-          1. **Job Consistency**: Do the changes maintain overall job consistency?
-          2. **Valid Dependencies**: Are all step dependencies logically valid (no circular refs)?
-          3. **Semantic Versioning**: Was the version bumped appropriately (major/minor/patch)?
-          4. **Changelog Updated**: Is the changelog updated with a description of changes?
-          5. **User Understanding**: Does the user understand the impact of the changes?
-          6. **Breaking Changes**: Were any breaking changes clearly communicated?
-          7. **Files Updated**: Are all affected files (job.yml, step files) updated?
-          8. **Sync Complete**: Has `deepwork sync` been run to regenerate commands?
+            1. **Job Consistency**: Do the changes maintain overall job consistency?
+            2. **Valid Dependencies**: Are all step dependencies logically valid (no circular refs)?
+            3. **Semantic Versioning**: Was the version bumped appropriately (major/minor/patch)?
+            4. **Changelog Updated**: Is the changelog updated with a description of changes?
+            5. **User Understanding**: Does the user understand the impact of the changes?
+            6. **Breaking Changes**: Were any breaking changes clearly communicated?
+            7. **Files Updated**: Are all affected files (job.yml, step files) updated?
+            8. **Sync Complete**: Has `deepwork sync` been run to regenerate commands?
 
-          If ANY criterion is not met, continue working to address it.
-          If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.
+            If ANY criterion is not met, continue working to address it.
+            If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.


### PR DESCRIPTION
Migrate job.yml files from the deprecated `stop_hooks` array format to the new `hooks.after_agent` structure. This aligns the job definitions with the lifecycle hooks system that maps generic hook names (like `after_agent`) to platform-specific implementations in the adapters (e.g., Claude's "Stop" hook).

The adapter hook_name_mapping already handles the translation:
- Claude: after_agent -> "Stop"
- Gemini: No command-level hooks (empty mapping)

Files updated:
- .deepwork/jobs/add_platform/job.yml
- .deepwork/jobs/deepwork_jobs/job.yml
- src/deepwork/standard_jobs/deepwork_jobs/job.yml