### PR TITLE
Add skills section to jobs configuration

### DIFF
--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -1,16 +1,50 @@
 name: deepwork_jobs
-version: "1.3.0"
+version: "1.4.0"
 summary: "DeepWork job management commands"
 description: |
-  Core commands for managing DeepWork jobs. These commands help you define new multi-step
-  workflows and refine existing ones.
+  # DeepWork Jobs Overview
 
-  The `define` command guides you through an interactive process to create a new job by
-  asking detailed questions about your workflow, understanding each step's inputs and outputs,
-  and generating all necessary files.
+  DeepWork jobs are multi-step AI workflows that break complex tasks into manageable,
+  repeatable steps. Each job is defined in a `job.yml` file and consists of:
 
-  The `refine` command helps you modify existing jobs safely by understanding what you want
-  to change, validating the impact, and ensuring consistency across your workflow.
+  - **Steps**: Individual tasks with clear inputs, outputs, and instructions
+  - **Dependencies**: Ordering constraints between steps
+  - **Hooks**: Quality validation loops that ensure outputs meet standards
+  - **Skills**: Reusable AI capabilities that jobs can install
+
+  ## How Jobs Work
+
+  Jobs follow a **define → implement → use** workflow:
+
+  1. **Define** (`/deepwork_jobs.define`): Interactive Q&A to understand your workflow
+     and create a `job.yml` specification. This captures what each step does, what
+     inputs it needs, and what outputs it produces.
+
+  2. **Implement** (`/deepwork_jobs.implement`): Generates detailed instruction files
+     for each step based on the spec. Creates the directory structure and syncs
+     commands to make them available as slash commands.
+
+  3. **Use**: Each step becomes a slash command like `/job_name.step_id`. Run steps
+     in order (respecting dependencies) to complete the workflow.
+
+  ## Refining Jobs
+
+  The `refine` command (`/deepwork_jobs.refine`) helps modify existing jobs safely
+  by understanding what you want to change, validating the impact, and ensuring
+  consistency across your workflow.
+
+  ## Job Structure
+
+  Jobs live in `.deepwork/jobs/[job_name]/` with:
+  - `job.yml` - The job specification
+  - `steps/` - Instruction files for each step
+  - `hooks/` - Optional hook scripts and prompts
+
+  ## Creating Jobs Casually
+
+  You can ask Claude to create jobs naturally, like "Make a new job that does X"
+  or "I need a workflow for Y". Claude will invoke the appropriate commands
+  automatically.
 
 changelog:
   - version: "1.0.0"
@@ -21,6 +55,77 @@ changelog:
     changes: "Updated to support array of stop hooks"
   - version: "1.3.0"
     changes: "Added policy awareness to implement step - suggests relevant policies after job implementation"
+  - version: "1.4.0"
+    changes: "Added skills section with workflow guide for casual job creation; enhanced description with comprehensive workflow documentation"
+
+skills:
+  - name: deepwork-jobs
+    description: |
+      Use this skill when the user wants to create, modify, or understand DeepWork jobs.
+      Triggers on phrases like "make a job", "create a workflow", "new job for", "define a job",
+      or questions about how DeepWork jobs work.
+    user_invocable: false
+    content: |
+      # DeepWork Jobs Workflow Guide
+
+      When users want to create or modify DeepWork jobs, guide them through the appropriate workflow.
+
+      ## Creating a New Job
+
+      To create a new job, follow this sequence:
+
+      1. **First, run `/deepwork_jobs.define`** - This will:
+         - Ask the user about their workflow goals
+         - Understand the steps, inputs, and outputs
+         - Create the `job.yml` specification file
+         - The define step uses interactive Q&A, so let it guide the conversation
+
+      2. **Then, run `/deepwork_jobs.implement`** - This will:
+         - Read the job.yml created by define
+         - Generate instruction files for each step
+         - Run `deepwork sync` to create slash commands
+         - Create an implementation summary
+
+      3. **Tell the user to reload commands** - After implementation, they need to:
+         - Run `/reload` or restart their session to see new commands
+
+      ## Modifying an Existing Job
+
+      To modify an existing job:
+
+      1. **Run `/deepwork_jobs.refine`** with the job name
+         - This handles changes safely and maintains consistency
+         - Updates version numbers and changelog
+         - Re-syncs commands after changes
+
+      ## Understanding the Workflow
+
+      When users ask questions about jobs, explain:
+
+      - Jobs are multi-step workflows defined in `.deepwork/jobs/[name]/job.yml`
+      - Each step has inputs (user parameters or files from previous steps) and outputs
+      - Steps can have dependencies on other steps
+      - Quality hooks (stop_hooks) enable AI self-validation before completing steps
+      - Skills can be bundled with jobs to provide additional capabilities
+
+      ## Example Interaction
+
+      User: "I want to create a job for writing blog posts"
+
+      Response: "I'll help you create a blog post workflow! Let me start the job definition process."
+      Then invoke: `/deepwork_jobs.define`
+
+      User: "How do jobs work?"
+
+      Response: Explain the define → implement → use workflow from the job description.
+
+      ## Important Notes
+
+      - Always use the slash commands (`/deepwork_jobs.define`, etc.) rather than trying
+        to create job files manually - the commands handle validation and structure
+      - The define step is interactive - it will ask questions; don't try to create
+        the job.yml directly without going through the Q&A process
+      - After implementing a job, always remind users to reload commands
 
 steps:
   - id: define
@@ -41,9 +146,18 @@ steps:
           2. **Clear Inputs/Outputs**: Does every step have clearly defined inputs and outputs?
           3. **Logical Dependencies**: Do step dependencies make sense and avoid circular references?
           4. **Concise Summary**: Is the summary under 200 characters and descriptive?
-          5. **Rich Description**: Does the description provide enough context for future refinement?
-          6. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
-          7. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
+          5. **Rich Description**: Does the description explain:
+             - What the workflow accomplishes
+             - How the steps connect (the workflow flow)
+             - Any background context or prerequisites users need
+             - How to use the job effectively
+          6. **Skills Quality** (if skills are included):
+             - Does each skill have a clear description explaining when Claude should use it?
+             - Does the skill content provide comprehensive workflow guidance?
+             - Does the content explain each step and when to use it?
+             - Are there domain-specific tips or context included?
+          7. **Valid Schema**: Does the job.yml follow the required schema (name, version, summary, steps)?
+          8. **File Created**: Has the job.yml file been created in `.deepwork/jobs/[job_name]/job.yml`?
 
           If ANY criterion is not met, continue working to address it.
           If ALL criteria are satisfied, include `<promise>QUALITY_COMPLETE</promise>` in your response.


### PR DESCRIPTION
- Add skills schema to job_schema.py with Claude Code SKILL.md format support
- Update ClaudeAdapter.sync_skills() to install skills to .claude/skills/
- Update sync.py to collect and sync skills from all jobs
- Add parser.py Skill dataclass for skills parsing

Enhanced deepwork_jobs job.yml:
- Comprehensive description explaining how DeepWork jobs work
- Document the define → implement → use workflow
- Add deepwork-jobs skill for casual job creation assistance

Updated define step instructions:
- New section on writing rich workflow context in descriptions
- New section on considering skills for jobs
- Updated validation rules and quality criteria for skills
- Updated stop_hooks to validate skill content quality

This enables users to casually ask "Make a new job that does X" and have Claude automatically guide them through the job creation workflow.