### PR TITLE
Allow manual triggering of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to release workflow
- Enables manual runs from Actions tab for testing or re-publishing

## Test plan
- [ ] Go to Actions → Release to PyPI → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)