### PR TITLE
Fix CLA Assistant 'Not Found' error

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,10 +31,6 @@ jobs:
           branch: 'IMPT_cla_signatures'
           allowlist: 'dependabot[bot],github-actions[bot],claude,copilot'
           
-          # Customizable messages
-          remote-organization-name: 'Unsupervised.com, Inc.'
-          remote-repository-name: 'deepwork'
-          
           # Custom text for the CLA comment
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'


### PR DESCRIPTION
## Summary
- Remove `remote-organization-name` and `remote-repository-name` parameters from CLA workflow
- These params are only needed when storing signatures in a **different** repository
- Since we store signatures in the same repo (on `IMPT_cla_signatures` branch), they were causing the action to look for a non-existent repo

## Test plan
- [ ] Merge this PR and verify CLA check passes on PR #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)