### PR TITLE
Fix CLA action to only run on PR branches

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize]
 
 # Explicitly set permissions for the workflow
 permissions:


### PR DESCRIPTION
Remove 'closed' event type from pull_request_target trigger to prevent the CLA check from running on main when a PR is merged. The CLA check only needs to run when PRs are opened or updated with new commits.