### PR TITLE
Add git hook for deepwork install

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,29 @@
+#!/bin/sh
+# post-checkout hook - runs deepwork install when switching branches
+#
+# Arguments:
+#   $1 - ref of the previous HEAD
+#   $2 - ref of the new HEAD
+#   $3 - flag: 1 = branch checkout, 0 = file checkout
+
+OLD_REF="$1"
+NEW_REF="$2"
+CHECKOUT_TYPE="$3"
+
+# Only run on branch checkouts, not file checkouts
+if [ "$CHECKOUT_TYPE" != "1" ]; then
+    exit 0
+fi
+
+# Only run if the branch actually changed
+if [ "$OLD_REF" = "$NEW_REF" ]; then
+    exit 0
+fi
+
+# Check if deepwork command is available
+if ! command -v deepwork >/dev/null 2>&1; then
+    exit 0
+fi
+
+echo "Branch changed, running deepwork install..."
+deepwork install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,17 @@ export PYTHONPATH="$PWD/src:$PYTHONPATH"
 export DEEPWORK_DEV=1
 ```
 
+### Setting Up Git Hooks
+
+The repository includes git hooks that automatically run `deepwork install` when you switch branches, keeping your local deepwork configuration in sync. To enable them:
+
+```bash
+# Configure git to use the project's hooks directory
+git config core.hooksPath .githooks
+```
+
+This only needs to be done once per clone.
+
 ## Installing DeepWork Locally
 
 To use your local development version of DeepWork, install it in **editable mode**. This allows you to make changes to the code and have them immediately reflected without reinstalling.


### PR DESCRIPTION
Add git hook that automatically runs `deepwork install` when switching branches, keeping local deepwork configuration in sync with the branch.