### PR TITLE
Fix that CI checks are not running in merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,9 +8,6 @@ on:
     branches: [main]
   # Run in merge queue but skip the step (shows as passing check)
   merge_group:
-    types: [checks_requested]
-    # Note: Don't use branches filter here - merge queue refs like
-    # gh-readonly-queue/main/pr-N-xxx don't match simple branch globs
   workflow_dispatch:
 
 # Explicitly set permissions for the workflow

--- a/.github/workflows/claude-code-test.yml
+++ b/.github/workflows/claude-code-test.yml
@@ -14,9 +14,6 @@ on:
     branches: [main]
   # Run in the merge queue to validate before merging
   merge_group:
-    types: [checks_requested]
-    # Note: Don't use branches filter here - merge queue refs like
-    # gh-readonly-queue/main/pr-N-xxx don't match simple branch globs
 
 # Ensure only one instance runs at a time per PR/branch
 concurrency:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [main]
   merge_group:
-    types: [checks_requested]
-    # Note: Don't use branches filter here - merge queue refs like
-    # gh-readonly-queue/main/pr-N-xxx don't match simple branch globs
   workflow_dispatch:
 
 # Minimal permissions for this workflow


### PR DESCRIPTION
CI checks that run in the PR don't run when it goes to the merge queue.