### PR TITLE
Add job descriptions to meta skill body

### DIFF
--- a/.claude/skills/add_platform.add_capabilities/SKILL.md
+++ b/.claude/skills/add_platform.add_capabilities/SKILL.md
@@ -176,14 +176,11 @@ When you find a new hook type, consider whether it maps to an existing pattern o
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.claude/skills/add_platform.implement/SKILL.md
+++ b/.claude/skills/add_platform.implement/SKILL.md
@@ -272,14 +272,11 @@ The templates use Jinja2 and should produce files that match exactly what the pl
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.claude/skills/add_platform.research/SKILL.md
+++ b/.claude/skills/add_platform.research/SKILL.md
@@ -226,14 +226,11 @@ Take time to be thorough - incomplete documentation will slow down subsequent st
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.claude/skills/add_platform.verify/SKILL.md
+++ b/.claude/skills/add_platform.verify/SKILL.md
@@ -151,14 +151,11 @@ Take time to verify each aspect - finding issues now is much better than having 
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.claude/skills/add_platform/SKILL.md
+++ b/.claude/skills/add_platform/SKILL.md
@@ -11,14 +11,11 @@ description: "Add a new AI platform to DeepWork with adapter, templates, and tes
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.claude/skills/commit.commit_and_push/SKILL.md
+++ b/.claude/skills/commit.commit_and_push/SKILL.md
@@ -118,14 +118,10 @@ This is the final step of the commit workflow. It ensures the user has reviewed 
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 

--- a/.claude/skills/commit.lint/SKILL.md
+++ b/.claude/skills/commit.lint/SKILL.md
@@ -108,14 +108,10 @@ This step ensures code quality and consistency before committing. It runs after 
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 

--- a/.claude/skills/commit.test/SKILL.md
+++ b/.claude/skills/commit.test/SKILL.md
@@ -86,14 +86,10 @@ This is the first step of the commit workflow. Tests must pass before proceeding
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 ## Required Inputs

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -11,14 +11,10 @@ description: "Run tests, lint, and commit code changes"
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 ## Available Steps

--- a/.claude/skills/update.job/SKILL.md
+++ b/.claude/skills/update.job/SKILL.md
@@ -109,13 +109,9 @@ A workflow for maintaining standard jobs bundled with DeepWork. Standard jobs
 `src/deepwork/standard_jobs/` and must be edited there—never in `.deepwork/jobs/`
 or `.claude/commands/` directly.
 
-This job guides you through:
-1. Identifying which standard job(s) to update from conversation context
-2. Making changes in the correct source location (`src/deepwork/standard_jobs/[job_name]/`)
-3. Running `deepwork install` to propagate changes to `.deepwork/` and command directories
-4. Verifying the sync completed successfully
-
-Use this job whenever you need to modify job.yml files, step instructions, or hooks
+This job identifies which standard jobs to update from conversation context, makes
+changes in the correct source location, and propagates them via `deepwork install`.
+Use this whenever you need to modify job.yml files, step instructions, or hooks
 for any standard job in the DeepWork repository.
 
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -14,13 +14,9 @@ A workflow for maintaining standard jobs bundled with DeepWork. Standard jobs
 `src/deepwork/standard_jobs/` and must be edited there—never in `.deepwork/jobs/`
 or `.claude/commands/` directly.
 
-This job guides you through:
-1. Identifying which standard job(s) to update from conversation context
-2. Making changes in the correct source location (`src/deepwork/standard_jobs/[job_name]/`)
-3. Running `deepwork install` to propagate changes to `.deepwork/` and command directories
-4. Verifying the sync completed successfully
-
-Use this job whenever you need to modify job.yml files, step instructions, or hooks
+This job identifies which standard jobs to update from conversation context, makes
+changes in the correct source location, and propagates them via `deepwork install`.
+Use this whenever you need to modify job.yml files, step instructions, or hooks
 for any standard job in the DeepWork repository.
 
 

--- a/.deepwork/jobs/add_platform/job.yml
+++ b/.deepwork/jobs/add_platform/job.yml
@@ -5,14 +5,11 @@ summary: "Add a new AI platform to DeepWork with adapter, templates, and tests"
 description: |
   A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-  This job guides you through four phases:
-  1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-  2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-  3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-  4. **Verify**: Ensure installation works correctly and produces expected files
-
   The workflow ensures consistency across all supported platforms and maintains
-  comprehensive test coverage for new functionality.
+  comprehensive test coverage for new functionality. It starts with research to
+  capture the platform's configuration and hooks documentation, then adds any new
+  hook capabilities to the schema and existing adapters, implements the full adapter
+  with templates and tests, and finally verifies installation works correctly.
 
   **Important Notes**:
   - Only hooks available on slash command definitions should be captured

--- a/.deepwork/jobs/commit/job.yml
+++ b/.deepwork/jobs/commit/job.yml
@@ -4,14 +4,10 @@ summary: "Run tests, lint, and commit code changes"
 description: |
   A workflow for preparing and committing code changes with quality checks.
 
-  This job runs tests until they pass, formats and lints code with ruff,
-  then reviews changed files before committing and pushing. The lint step
-  uses a sub-agent to reduce context usage.
-
-  Steps:
-  1. test - Pull latest code and run tests until they pass
-  2. lint - Format and lint code with ruff (runs in sub-agent)
-  3. commit_and_push - Review changes and commit/push
+  This job ensures code quality before committing by running the test suite until
+  all tests pass, then formatting and linting with ruff. The lint step runs in a
+  sub-agent to reduce context usage. Finally, it reviews changed files with you
+  before creating the commit and pushing to the remote.
 
 changelog:
   - version: "1.0.0"

--- a/.deepwork/jobs/update/job.yml
+++ b/.deepwork/jobs/update/job.yml
@@ -7,13 +7,9 @@ description: |
   `src/deepwork/standard_jobs/` and must be edited there—never in `.deepwork/jobs/`
   or `.claude/commands/` directly.
 
-  This job guides you through:
-  1. Identifying which standard job(s) to update from conversation context
-  2. Making changes in the correct source location (`src/deepwork/standard_jobs/[job_name]/`)
-  3. Running `deepwork install` to propagate changes to `.deepwork/` and command directories
-  4. Verifying the sync completed successfully
-
-  Use this job whenever you need to modify job.yml files, step instructions, or hooks
+  This job identifies which standard jobs to update from conversation context, makes
+  changes in the correct source location, and propagates them via `deepwork install`.
+  Use this whenever you need to modify job.yml files, step instructions, or hooks
   for any standard job in the DeepWork repository.
 
 changelog:

--- a/.gemini/skills/add_platform/add_capabilities.toml
+++ b/.gemini/skills/add_platform/add_capabilities.toml
@@ -163,14 +163,11 @@ When you find a new hook type, consider whether it maps to an existing pattern o
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.gemini/skills/add_platform/implement.toml
+++ b/.gemini/skills/add_platform/implement.toml
@@ -255,14 +255,11 @@ The templates use Jinja2 and should produce files that match exactly what the pl
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.gemini/skills/add_platform/index.toml
+++ b/.gemini/skills/add_platform/index.toml
@@ -15,14 +15,11 @@ prompt = """
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.gemini/skills/add_platform/research.toml
+++ b/.gemini/skills/add_platform/research.toml
@@ -212,14 +212,11 @@ Take time to be thorough - incomplete documentation will slow down subsequent st
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.gemini/skills/add_platform/verify.toml
+++ b/.gemini/skills/add_platform/verify.toml
@@ -139,14 +139,11 @@ Take time to verify each aspect - finding issues now is much better than having 
 
 A workflow for adding support for a new AI platform (like Cursor, Windsurf, etc.) to DeepWork.
 
-This job guides you through four phases:
-1. **Research**: Capture the platform's CLI configuration and hooks system documentation
-2. **Add Capabilities**: Update the job schema and adapters with any new hook events
-3. **Implement**: Create the platform adapter, templates, tests (100% coverage), and README updates
-4. **Verify**: Ensure installation works correctly and produces expected files
-
 The workflow ensures consistency across all supported platforms and maintains
-comprehensive test coverage for new functionality.
+comprehensive test coverage for new functionality. It starts with research to
+capture the platform's configuration and hooks documentation, then adds any new
+hook capabilities to the schema and existing adapters, implements the full adapter
+with templates and tests, and finally verifies installation works correctly.
 
 **Important Notes**:
 - Only hooks available on slash command definitions should be captured

--- a/.gemini/skills/commit/commit_and_push.toml
+++ b/.gemini/skills/commit/commit_and_push.toml
@@ -109,14 +109,10 @@ This is the final step of the commit workflow. It ensures the user has reviewed 
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 

--- a/.gemini/skills/commit/index.toml
+++ b/.gemini/skills/commit/index.toml
@@ -15,14 +15,10 @@ prompt = """
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 ## Available Steps

--- a/.gemini/skills/commit/lint.toml
+++ b/.gemini/skills/commit/lint.toml
@@ -100,14 +100,10 @@ This step ensures code quality and consistency before committing. It runs after 
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 

--- a/.gemini/skills/commit/test.toml
+++ b/.gemini/skills/commit/test.toml
@@ -77,14 +77,10 @@ This is the first step of the commit workflow. Tests must pass before proceeding
 
 A workflow for preparing and committing code changes with quality checks.
 
-This job runs tests until they pass, formats and lints code with ruff,
-then reviews changed files before committing and pushing. The lint step
-uses a sub-agent to reduce context usage.
-
-Steps:
-1. test - Pull latest code and run tests until they pass
-2. lint - Format and lint code with ruff (runs in sub-agent)
-3. commit_and_push - Review changes and commit/push
+This job ensures code quality before committing by running the test suite until
+all tests pass, then formatting and linting with ruff. The lint step runs in a
+sub-agent to reduce context usage. Finally, it reviews changed files with you
+before creating the commit and pushing to the remote.
 
 
 ## Required Inputs

--- a/.gemini/skills/update/index.toml
+++ b/.gemini/skills/update/index.toml
@@ -18,13 +18,9 @@ A workflow for maintaining standard jobs bundled with DeepWork. Standard jobs
 `src/deepwork/standard_jobs/` and must be edited there—never in `.deepwork/jobs/`
 or `.claude/commands/` directly.
 
-This job guides you through:
-1. Identifying which standard job(s) to update from conversation context
-2. Making changes in the correct source location (`src/deepwork/standard_jobs/[job_name]/`)
-3. Running `deepwork install` to propagate changes to `.deepwork/` and command directories
-4. Verifying the sync completed successfully
-
-Use this job whenever you need to modify job.yml files, step instructions, or hooks
+This job identifies which standard jobs to update from conversation context, makes
+changes in the correct source location, and propagates them via `deepwork install`.
+Use this whenever you need to modify job.yml files, step instructions, or hooks
 for any standard job in the DeepWork repository.
 
 

--- a/.gemini/skills/update/job.toml
+++ b/.gemini/skills/update/job.toml
@@ -100,13 +100,9 @@ A workflow for maintaining standard jobs bundled with DeepWork. Standard jobs
 `src/deepwork/standard_jobs/` and must be edited there—never in `.deepwork/jobs/`
 or `.claude/commands/` directly.
 
-This job guides you through:
-1. Identifying which standard job(s) to update from conversation context
-2. Making changes in the correct source location (`src/deepwork/standard_jobs/[job_name]/`)
-3. Running `deepwork install` to propagate changes to `.deepwork/` and command directories
-4. Verifying the sync completed successfully
-
-Use this job whenever you need to modify job.yml files, step instructions, or hooks
+This job identifies which standard jobs to update from conversation context, makes
+changes in the correct source location, and propagates them via `deepwork install`.
+Use this whenever you need to modify job.yml files, step instructions, or hooks
 for any standard job in the DeepWork repository.
 
 


### PR DESCRIPTION
- Add "## Overview" section header in both Claude and Gemini meta skill templates to better structure the job description content
- Rewrite job.yml descriptions for commit, add_platform, and update jobs to be more narrative and avoid duplicating step information that's already shown in the Available Steps section
- Regenerate all skill files via deepwork sync to reflect the template changes

This makes the SKILL.md files clearer and more readable by providing context in the Overview section without redundant step lists.