### PR TITLE
Sync capture prompt work tree script

### DIFF
--- a/src/deepwork/standard_jobs/deepwork_rules/hooks/capture_prompt_work_tree.sh
+++ b/src/deepwork/standard_jobs/deepwork_rules/hooks/capture_prompt_work_tree.sh
@@ -8,11 +8,19 @@
 # The baseline contains ALL tracked files (not just changed files) so that
 # the rules_check hook can determine which files are genuinely new vs which
 # files existed before and were just modified.
+#
+# It also captures the HEAD commit ref so that committed changes can be detected
+# by comparing HEAD at Stop time to the captured ref.
 
 set -e
 
 # Ensure .deepwork directory exists
 mkdir -p .deepwork
+
+# Save the current HEAD commit ref for detecting committed changes
+# This is used by get_changed_files_prompt() to detect files changed since prompt,
+# even if those changes were committed during the agent response.
+git rev-parse HEAD > .deepwork/.last_head_ref 2>/dev/null || echo "" > .deepwork/.last_head_ref
 
 # Save ALL tracked files (not just changed files)
 # This is critical for created: mode rules to distinguish between:


### PR DESCRIPTION
The .deepwork version was updated in PR #85 with HEAD ref capture functionality, but the standard_jobs source was not updated. This syncs the newer version which includes:
- Capture HEAD commit ref at prompt time
- Used by get_changed_files_prompt() to detect committed changes