### PR TITLE
Fix infinite loop bug in rules system when promise tags aren't recogn…

### DIFF
--- a/src/deepwork/hooks/rules_check.py
+++ b/src/deepwork/hooks/rules_check.py
@@ -611,6 +611,16 @@ def rules_check_hook(hook_input: HookInput) -> HookOutput:
             ):
                 continue
 
+            # For PROMPT rules, also skip if already QUEUED (already shown to agent).
+            # This prevents infinite loops when transcript is unavailable or promise
+            # tags haven't been written yet. The agent has already seen this rule.
+            if (
+                existing
+                and existing.status == QueueEntryStatus.QUEUED
+                and rule.action_type == ActionType.PROMPT
+            ):
+                continue
+
             # Create queue entry if new
             if not existing:
                 queue.create_entry(


### PR DESCRIPTION
The rules system would create an infinite loop when:
1. Rules with compare_to: base fire when src/ files are modified
2. The assistant responds with <promise>Rule Name</promise> tags
3. The stop hook runs again and fires the same rules, ignoring promise tags

Root cause: When a PROMPT action rule fires, a queue entry is created with QUEUED status. The hook only skipped rules with PASSED or SKIPPED status, so QUEUED rules would fire again even though they had already been shown to the agent. The promise tag mechanism relies on reading the transcript, which may not be available or may not contain the current response yet.

Fix: Skip PROMPT rules that already have a QUEUED entry, since the agent has already seen this rule and doesn't need to see it again.

Added tests:
- test_queued_prompt_rule_does_not_refire
- test_rule_fires_again_after_queue_cleared
- test_promise_tag_still_prevents_firing