### PR TITLE
Add timeout to deepwork install hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,7 +104,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run deepwork install"
+            "command": "uv run deepwork install",
+            "timeout": 5000
           }
         ]
       }


### PR DESCRIPTION
Prevents the deepwork install command from hanging indefinitely during session startup.