### PR TITLE
Remove deepwork install startup setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -98,18 +98,6 @@
     ]
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "uv run deepwork install",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
     "UserPromptSubmit": [
       {
         "matcher": "",


### PR DESCRIPTION
The SessionStart hook that automatically ran 'uv run deepwork install' at the start of each session is no longer needed.

Turns out that was making sub-agent invocations hang