### PR TITLE
Update skill template docs to use generic "agent" terminology

### DIFF
--- a/.deepwork/rules/skill-template-best-practices.md
+++ b/.deepwork/rules/skill-template-best-practices.md
@@ -24,7 +24,7 @@ The description appears in skill search results and helps users find the right s
 ## Prompt Structure
 
 1. **Specificity first** - Detailed directions upfront prevent course corrections later
-2. **Plan before action** - Ask claude prompt runtime to analyze/plan before implementing
+2. **Plan before action** - Ask agent to analyze/plan before implementing
 3. **Reference concrete files** - Use specific paths, not general descriptions
 4. **Include context** - Mention edge cases, preferred patterns, and expected outcomes
 
@@ -32,7 +32,7 @@ The description appears in skill search results and helps users find the right s
 
 1. **Make measurable** - Criteria should be verifiable, not subjective
 2. **Focus on outcomes** - What the output should achieve, not process steps
-3. **Keep actionable** - Claude prompt runtime should be able to self-evaluate against criteria
+3. **Keep actionable** - Agent should be able to self-evaluate against criteria
 
 ## Platform Considerations
 


### PR DESCRIPTION
## Summary
Updated the skill template best practices documentation to use generic "agent" terminology instead of "claude prompt runtime" for broader applicability and clarity.

## Changes
- Replaced "claude prompt runtime" with "agent" in two locations:
  - Line 27: Updated prompt structure guidance to reference "agent" for analysis/planning tasks
  - Line 34: Updated quality criteria to reference "agent" for self-evaluation capabilities

## Rationale
This change makes the documentation more platform-agnostic and easier to understand for users working with different agent implementations. The term "agent" is more universally understood and doesn't tie the best practices to a specific runtime implementation.