### PR TITLE
Add `deepwork rules clear_queue` command for queue management

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -120,8 +120,7 @@
       "Skill(manual_tests.run_fire_tests)",
       "Skill(deepwork_rules)",
       "Skill(deepwork_rules.define)",
-      "Bash(rm -rf .deepwork/tmp/rules/queue/**)",
-      "Bash(rm -rf .deepwork/tmp/rules/queue/*.json)"
+      "Bash(deepwork rules clear_queue)"
     ]
   },
   "hooks": {

--- a/.deepwork/jobs/manual_tests/steps/run_fire_tests.md
+++ b/.deepwork/jobs/manual_tests/steps/run_fire_tests.md
@@ -49,13 +49,13 @@ For EACH test below, follow this cycle:
 6. **Revert changes and clear queue** (MANDATORY after each test):
    ```bash
    git reset HEAD manual_tests/ && git checkout -- manual_tests/ && rm -f manual_tests/test_created_mode/new_config.yml
-   rm -rf .deepwork/tmp/rules/queue/*.json 2>/dev/null || true
+   deepwork rules clear_queue
    ```
    **Why this command sequence**:
    - `git reset HEAD manual_tests/` - Unstages files from the index (rules_check uses `git add -A` which stages changes)
    - `git checkout -- manual_tests/` - Reverts working tree to match HEAD
    - `rm -f ...` - Removes any new files created during tests
-   - The queue clear removes rules that have been shown (status=QUEUED) so they can fire again
+   - `deepwork rules clear_queue` - Clears the rules queue so rules can fire again
 7. **Check for early termination**: If **2 tests have now failed**, immediately:
    - Stop running any remaining tests
    - Report the results summary showing which tests passed/failed
@@ -122,7 +122,7 @@ Record the result after each test:
 
 - **Sub-agents spawned**: Tests were run using the Task tool to spawn sub-agents - the main agent did NOT edit files directly
 - **Serial execution**: Sub-agents were launched ONE AT A TIME, not in parallel
-- **Git reverted and queue cleared between tests**: `git reset HEAD manual_tests/ && git checkout -- manual_tests/` and `rm -rf .deepwork/tmp/rules/queue/*.json` was run after each test
+- **Git reverted and queue cleared between tests**: `git reset HEAD manual_tests/ && git checkout -- manual_tests/` and `deepwork rules clear_queue` was run after each test
 - **Hooks observed (not triggered)**: The main agent observed hook behavior without manually running rules_check - hooks fired AUTOMATICALLY
 - **Blocking behavior verified**: For each test run, the appropriate blocking hook fired automatically when the sub-agent returned
 - **Early termination on 2 failures**: If 2 tests failed, testing halted immediately and results were reported

--- a/.deepwork/jobs/manual_tests/steps/run_not_fire_tests.md
+++ b/.deepwork/jobs/manual_tests/steps/run_not_fire_tests.md
@@ -80,14 +80,14 @@ Run all 8 "should NOT fire" tests in **parallel** sub-agents, then verify no blo
    Run these commands to clean up:
    ```bash
    git reset HEAD manual_tests/ && git checkout -- manual_tests/ && rm -f manual_tests/test_created_mode/new_config.yml
-   rm -rf .deepwork/tmp/rules/queue/*.json 2>/dev/null || true
+   deepwork rules clear_queue
    ```
 
    **Why this command sequence**:
    - `git reset HEAD manual_tests/` - Unstages files from the index (rules_check uses `git add -A` which stages changes)
    - `git checkout -- manual_tests/` - Reverts working tree to match HEAD
    - `rm -f manual_tests/test_created_mode/new_config.yml` - Removes any new files created during tests
-   - The queue clear removes rules that have been shown (status=QUEUED) so they can fire again
+   - `deepwork rules clear_queue` - Clears the rules queue so rules can fire again
 
 ## Quality Criteria
 
@@ -95,7 +95,7 @@ Run all 8 "should NOT fire" tests in **parallel** sub-agents, then verify no blo
 - **Parallel execution**: All 8 sub-agents were launched in a single message (parallel)
 - **Hooks observed (not triggered)**: The main agent observed hook behavior without manually running rules_check
 - **Early termination on 2 failures**: If 2 tests failed, testing halted immediately and results were reported
-- **Changes reverted and queue cleared**: `git reset HEAD manual_tests/ && git checkout -- manual_tests/` and `rm -rf .deepwork/tmp/rules/queue/*.json` was run after tests completed (regardless of pass/fail)
+- **Changes reverted and queue cleared**: `git reset HEAD manual_tests/ && git checkout -- manual_tests/` and `deepwork rules clear_queue` was run after tests completed (regardless of pass/fail)
 - When all criteria are met, include `<promise>✓ Quality Criteria Met</promise>` in your response
 
 ## Reference

--- a/src/deepwork/cli/main.py
+++ b/src/deepwork/cli/main.py
@@ -16,11 +16,13 @@ def cli() -> None:
 # Import commands
 from deepwork.cli.hook import hook  # noqa: E402
 from deepwork.cli.install import install  # noqa: E402
+from deepwork.cli.rules import rules  # noqa: E402
 from deepwork.cli.sync import sync  # noqa: E402
 
 cli.add_command(install)
 cli.add_command(sync)
 cli.add_command(hook)
+cli.add_command(rules)
 
 
 if __name__ == "__main__":

--- a/src/deepwork/cli/rules.py
+++ b/src/deepwork/cli/rules.py
@@ -1,0 +1,32 @@
+"""Rules command for DeepWork CLI."""
+
+import click
+from rich.console import Console
+
+from deepwork.core.rules_queue import RulesQueue
+
+console = Console()
+
+
+@click.group()
+def rules() -> None:
+    """Manage DeepWork rules and queue."""
+    pass
+
+
+@rules.command(name="clear_queue")
+def clear_queue() -> None:
+    """
+    Clear all entries from the rules queue.
+
+    Removes all JSON files from .deepwork/tmp/rules/queue/.
+    This is useful for resetting the queue between tests or after
+    manual verification of rule states.
+    """
+    queue = RulesQueue()
+    count = queue.clear()
+
+    if count == 0:
+        console.print("[yellow]Queue is already empty[/yellow]")
+    else:
+        console.print(f"[green]Cleared {count} queue entry/entries[/green]")


### PR DESCRIPTION
## Summary
Introduces a new CLI command `deepwork rules clear_queue` to replace manual file deletion commands for clearing the rules queue. This improves usability and provides a cleaner interface for queue management.

## Changes
- **New CLI command**: Added `deepwork rules clear_queue` subcommand under a new `rules` command group
  - Clears all JSON entries from `.deepwork/tmp/rules/queue/`
  - Provides user-friendly feedback (shows count of cleared entries or "already empty" message)
  - Implemented in new `src/deepwork/cli/rules.py` module

- **Updated documentation**: Replaced all instances of manual queue clearing commands
  - Changed `rm -rf .deepwork/tmp/rules/queue/*.json` to `deepwork rules clear_queue` in:
    - `.claude/settings.json` (deepwork_rules.define hook)
    - `.deepwork/jobs/manual_tests/steps/run_fire_tests.md`
    - `.deepwork/jobs/manual_tests/steps/run_not_fire_tests.md`
  - Updated explanatory comments to reference the new command

- **CLI integration**: Registered new `rules` command group in main CLI entry point

## Implementation Details
- Uses existing `RulesQueue` class from `deepwork.core.rules_queue` for queue operations
- Provides colored console output using Rich library for better UX
- Returns count of cleared entries for transparency
- Handles empty queue gracefully with appropriate messaging