### PR TITLE
Use deepwork CLI for hook commands instead of python -m

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -m deepwork.hooks.rules_check"
+            "command": "deepwork hook rules_check"
           }
         ]
       }
@@ -166,7 +166,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -m deepwork.hooks.rules_check"
+            "command": "deepwork hook rules_check"
           }
         ]
       }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1147,7 +1147,7 @@ The hooks are installed to `.claude/settings.json` during `deepwork sync`:
 {
   "hooks": {
     "Stop": [
-      {"matcher": "", "hooks": [{"type": "command", "command": "python -m deepwork.hooks.rules_check"}]}
+      {"matcher": "", "hooks": [{"type": "command", "command": "deepwork hook rules_check"}]}
     ]
   }
 }

--- a/src/deepwork/core/hooks_syncer.py
+++ b/src/deepwork/core/hooks_syncer.py
@@ -35,8 +35,10 @@ class HookEntry:
             Command string to execute
         """
         if self.module:
-            # Python module - run directly with python -m
-            return f"python -m {self.module}"
+            # Python module - use deepwork hook CLI for portability
+            # Extract hook name from module path (e.g., "deepwork.hooks.rules_check" -> "rules_check")
+            hook_name = self.module.rsplit(".", 1)[-1]
+            return f"deepwork hook {hook_name}"
         elif self.script:
             # Script path is: .deepwork/jobs/{job_name}/hooks/{script}
             script_path = self.job_dir / "hooks" / self.script

--- a/tests/unit/test_hooks_syncer.py
+++ b/tests/unit/test_hooks_syncer.py
@@ -43,7 +43,7 @@ class TestHookEntry:
         )
 
         cmd = entry.get_command(temp_dir)
-        assert cmd == "python -m deepwork.hooks.rules_check"
+        assert cmd == "deepwork hook rules_check"
 
 
 class TestJobHooks:


### PR DESCRIPTION
## Summary
Replace direct Python module invocation (`python -m deepwork.hooks.rules_check`) with the `deepwork hook` CLI command for better portability and maintainability.

## Changes
- **hooks_syncer.py**: Updated `get_command()` to extract the hook name from the module path and use the `deepwork hook {name}` CLI format instead of `python -m {module}`
- **settings.json**: Updated hook command examples to use the new CLI format
- **architecture.md**: Updated documentation to reflect the new hook command format
- **test_hooks_syncer.py**: Updated test assertion to expect the new command format

## Benefits
- **Portability**: The `deepwork hook` CLI command works regardless of how deepwork is installed (pip, poetry, editable mode, etc.)
- **Maintainability**: Centralizes hook execution logic in the CLI layer rather than relying on Python module paths
- **User Experience**: Simpler, more intuitive command format for users