### PR TITLE
Replace version check with rules clear_queue for dual utility

### DIFF
--- a/src/deepwork/hooks/check_version.sh
+++ b/src/deepwork/hooks/check_version.sh
@@ -17,8 +17,10 @@
 # deepwork is not installed, nothing else will work.
 
 check_deepwork_installed() {
-    # Try to run deepwork --version
-    if ! deepwork --version >/dev/null 2>&1; then
+    # Run 'deepwork rules clear_queue' instead of just '--version' for double utility:
+    # 1. Verifies that the 'deepwork' command is installed and directly invokable
+    # 2. Clears any stale rules from the queue, ensuring a clean slate for the session
+    if ! deepwork rules clear_queue >/dev/null 2>&1; then
         return 1
     fi
     return 0
@@ -34,7 +36,7 @@ print_deepwork_error() {
   ERROR: The 'deepwork' command is not available or cannot be directly invoked.
 
   DeepWork must be installed such that running 'deepwork' directly works.
-  For example, running 'deepwork --version' should succeed.
+  For example, running 'deepwork rules clear_queue' should succeed.
 
   IMPORTANT: Do NOT use 'uv run deepwork' or similar wrappers.
   The command must be directly invokable as just 'deepwork'.


### PR DESCRIPTION
## Summary
Updated the `check_deepwork_installed()` function to use `deepwork rules clear_queue` instead of `deepwork --version` for verifying installation. This change provides dual utility by both validating the installation and clearing stale rules from the queue.

## Key Changes
- Modified the installation check command from `deepwork --version` to `deepwork rules clear_queue`
- Updated error message documentation to reflect the new verification command
- Added clarifying comments explaining the dual benefits of the new approach

## Implementation Details
The new approach serves two purposes:
1. **Verification**: Confirms that the `deepwork` command is installed and directly invokable
2. **Maintenance**: Clears any stale rules from the queue, ensuring a clean slate for each session

This eliminates redundant command invocations and improves the initialization process by proactively cleaning up the queue state.