### PR TITLE
fix: remove nix result symlink and add dry-run build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release to PyPI
 on:
   release:
     types: [published]
+  # Dry-run build on PRs to catch build issues before release
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
 
 jobs:
   build:
@@ -37,6 +41,7 @@ jobs:
 
   publish:
     needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -53,6 +58,7 @@ jobs:
 
   update-homebrew:
     needs: publish
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Homebrew formula update

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ dmypy.json
 # direnv
 .direnv/
 
+# Nix build output
+result
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/hmxjpzgimzyf6gs76blmgxjims86cpq7-python3.11-deepwork-0.5.0


### PR DESCRIPTION
- Remove accidentally committed `result` symlink that pointed to nix store
- Add `result` to .gitignore to prevent future accidental commits
- Add PR trigger for release.yml changes to catch build issues early