### PR TITLE
Add agent notes for Claude Code prompt-based hooks

### DIFF
--- a/src/deepwork/templates/claude/AGENTS.md
+++ b/src/deepwork/templates/claude/AGENTS.md
@@ -7,6 +7,6 @@ Notes for AI agents working on Claude Code jinja templates.
 When writing prompt-based hooks (e.g., Stop hooks with `type: prompt`):
 
 - **Do NOT include instructions on how to return responses** (e.g., "respond with JSON", "return `{"ok": true}`"). Claude Code's internal instructions already specify the expected response format for prompt hooks.
-- Adding redundant response format instructions can cause conflicts or confusion with the built-in behavior.
+- Adding redundant response format instructions can cause conflicts or confusion with the built-in behavior. i.e. the hook will not block the agent from stopping.
 
 Reference: https://github.com/anthropics/claude-code/issues/11786


### PR DESCRIPTION
## Summary
Added documentation for AI agents working on Claude Code jinja templates, specifically addressing best practices when implementing prompt-based hooks.

## Changes
- Created `src/deepwork/templates/claude/AGENTS.md` with guidance for prompt-based hook implementation
- Documented that response format instructions should NOT be included in prompt hooks, as Claude Code's internal instructions already specify the expected format
- Added reference to related Claude Code issue for context

## Details
This documentation clarifies a common pitfall when writing prompt-based hooks (e.g., Stop hooks with `type: prompt`). Including redundant response format instructions can conflict with Claude Code's built-in behavior. The guide directs developers to rely on the framework's internal specifications rather than adding custom response format directives.