### PR TITLE
Remove synced adapters tracking and reload instructions display

### DIFF
--- a/src/deepwork/cli/sync.py
+++ b/src/deepwork/cli/sync.py
@@ -117,7 +117,6 @@ def sync_skills(project_path: Path) -> None:
     # Sync each platform
     generator = SkillGenerator()
     stats = {"platforms": 0, "skills": 0, "hooks": 0}
-    synced_adapters: list[AgentAdapter] = []
 
     for platform_name in platforms:
         try:
@@ -184,7 +183,6 @@ def sync_skills(project_path: Path) -> None:
                 console.print(f"    [red]✗[/red] Failed to sync skill permissions: {e}")
 
         stats["platforms"] += 1
-        synced_adapters.append(adapter)
 
     # Summary
     console.print()
@@ -201,11 +199,3 @@ def sync_skills(project_path: Path) -> None:
         table.add_row("Hooks synced", str(stats["hooks"]))
 
     console.print(table)
-    console.print()
-
-    # Show reload instructions for each synced platform
-    if synced_adapters and stats["skills"] > 0:
-        console.print("[bold]To use the new skills:[/bold]")
-        for adapter in synced_adapters:
-            console.print(f"  [cyan]{adapter.display_name}:[/cyan] {adapter.reload_instructions}")
-        console.print()


### PR DESCRIPTION
## Summary
Removes the tracking of synced adapters and the associated reload instructions display from the `sync_skills` command output.

## Changes
- Removed `synced_adapters` list initialization and population during platform sync loop
- Removed the conditional block that displayed reload instructions for each synced platform adapter
- Simplified the command output to end with the sync statistics table

## Details
The reload instructions feature has been removed from the sync workflow. This simplifies the CLI output and removes the need to track which adapters were successfully synced during the operation. Users will no longer see platform-specific reload instructions after running the sync command.