### PR TITLE
Use PAT token for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT with bypass permissions for pushing to protected branch
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Validate version format
         run: |


### PR DESCRIPTION
## Summary
Updated the create-release workflow to use a Personal Access Token (PAT) instead of the default GITHUB_TOKEN when checking out the repository. This allows the release process to push commits to protected branches.

## Changes
- Replaced `secrets.GITHUB_TOKEN` with `secrets.RELEASE_TOKEN` in the checkout action
- Added clarifying comment explaining the purpose of using a PAT with bypass permissions

## Details
The default GITHUB_TOKEN has limited permissions and cannot push to branches with protection rules enabled. By using a dedicated PAT stored in `RELEASE_TOKEN`, the workflow can successfully create and push release commits even when the target branch has protection rules configured (e.g., requiring status checks or code reviews).

**Note:** The `RELEASE_TOKEN` secret must be configured in the repository settings with appropriate permissions before this workflow will function.