### PR TITLE
Handle existing release branch in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Create release branch
         run: |
           VERSION="${{ inputs.version }}"
+          # Delete remote branch if it exists from a previous attempt
+          git push origin --delete "release/${VERSION}" 2>/dev/null || true
           git checkout -b "release/${VERSION}"
 
       - name: Update CHANGELOG.md


### PR DESCRIPTION
Delete any existing remote release branch from a previous attempt before pushing the new one.