### PR TITLE
Skip version checks for resumed/compacted sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- SessionStart hook now skips non-initial sessions (resume, compact/clear) by checking the `source` field in stdin JSON, reducing noise and redundant checks
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
Replace the unreliable environment variable-based re-entry guard with a source-based session detection mechanism. The hook now reads the session source from stdin JSON input to determine whether it's an initial startup or a resumed/compacted session, skipping redundant checks for non-initial sessions.

## Key Changes
- **Session source detection**: Added logic to parse the `source` field from hook input JSON (startup, resume, or clear)
- **Skip non-initial sessions**: Resume and clear sessions now immediately return empty JSON without running any checks, eliminating redundant version warnings
- **Removed environment variable guard**: Replaced the unreliable `DEEPWORK_VERSION_CHECK_DONE` environment variable approach with the more robust source-based detection
- **Backwards compatibility**: Sessions without a source field (older Claude Code versions) are treated as initial sessions to maintain compatibility
- **Comprehensive test coverage**: Added 8 new tests covering all session source scenarios, including edge cases

## Implementation Details
- Uses grep and sed for JSON parsing to avoid adding jq as a dependency
- The source detection happens before the deepwork installation check, so resumed sessions skip all checks efficiently
- Empty or missing stdin is handled gracefully, defaulting to running the full check for backwards compatibility
- Unknown future source values are treated conservatively as non-startup sessions