### PR TITLE
Refactor job validation from hooks to quality_criteria

### DIFF
--- a/.deepwork/jobs/commit/job.yml
+++ b/.deepwork/jobs/commit/job.yml
@@ -1,5 +1,5 @@
 name: commit
-version: "1.4.0"
+version: "1.5.0"
 summary: "Reviews code, runs tests, lints, and commits changes. Use when ready to commit work with quality checks."
 description: |
   A workflow for preparing and committing code changes with quality checks.
@@ -16,6 +16,8 @@ description: |
   4. commit_and_push - Review changes and commit/push
 
 changelog:
+  - version: "1.5.0"
+    changes: "Switched from hooks.after_agent to quality_criteria for cleaner step validation"
   - version: "1.4.0"
     changes: "Added changelog guidance: entries must go in [Unreleased] section, NEVER modify version numbers in pyproject.toml or CHANGELOG.md"
   - version: "1.3.0"
@@ -38,35 +40,23 @@ steps:
     outputs:
       - code_reviewed  # implicit state: code has been reviewed and issues addressed
     dependencies: []
-    hooks:
-      after_agent:
-        - prompt: |
-            Verify the code review is complete:
-            1. Changed files were identified
-            2. Sub-agent reviewed the code for general issues, DRY opportunities, naming clarity, and test coverage
-            3. All identified issues were addressed or documented as intentional
-            If ALL criteria are met, include `<promise>✓ Quality Criteria Met</promise>`.
+    quality_criteria:
+      - "Changed files were identified"
+      - "Sub-agent reviewed the code for general issues, DRY opportunities, naming clarity, and test coverage"
+      - "All identified issues were addressed or documented as intentional"
 
   - id: test
     name: "Run Tests"
     description: "Pulls latest code and runs tests until all pass. Use after code review passes to verify changes work correctly."
     instructions_file: steps/test.md
-    inputs:
-      - name: test_command
-        description: "Test command to run (optional - will auto-detect if not provided)"
+    inputs: []
     outputs:
       - tests_passing  # implicit state: all tests pass
     dependencies:
       - review
-    hooks:
-      after_agent:
-        - prompt: |
-            Verify the tests are passing:
-            1. Latest code was pulled from the branch
-            2. All tests completed successfully
-            3. No test failures or errors remain
-            4. Test output shows passing status
-            If ALL criteria are met, include `<promise>✓ Quality Criteria Met</promise>`.
+    quality_criteria:
+      - "Latest code was pulled from the branch"
+      - "All tests are passing"
 
   - id: lint
     name: "Lint Code"
@@ -77,14 +67,10 @@ steps:
       - code_formatted  # implicit state: code formatted and linted
     dependencies:
       - test
-    hooks:
-      after_agent:
-        - prompt: |
-            Verify the linting is complete:
-            1. ruff format was run successfully
-            2. ruff check was run successfully (with --fix)
-            3. No remaining lint errors
-            If ALL criteria are met, include `<promise>✓ Quality Criteria Met</promise>`.
+    quality_criteria:
+      - "ruff format was run successfully"
+      - "ruff check was run with --fix flag"
+      - "No remaining lint errors"
 
   - id: commit_and_push
     name: "Commit and Push"
@@ -95,14 +81,9 @@ steps:
       - changes_committed  # implicit state: changes committed and pushed
     dependencies:
       - lint
-    hooks:
-      after_agent:
-        - prompt: |
-            Verify the commit is ready:
-            1. Changed files list was reviewed by the agent
-            2. Files match what was modified during this session (or unexpected changes were investigated)
-            3. CHANGELOG.md was updated with entries in the [Unreleased] section (if changes warrant documentation)
-            4. Version numbers were NOT modified (pyproject.toml version and CHANGELOG version headers must remain unchanged)
-            5. Commit was created with appropriate message
-            6. Changes were pushed to remote
-            If ALL criteria are met, include `<promise>✓ Quality Criteria Met</promise>`.
+    quality_criteria:
+      - "Changed files were verified against expectations"
+      - "CHANGELOG.md was updated with entries in [Unreleased] section (if changes warrant documentation)"
+      - "Version numbers were NOT modified (pyproject.toml version and CHANGELOG version headers unchanged)"
+      - "Commit was created with appropriate message"
+      - "Changes were pushed to remote"

--- a/.deepwork/jobs/commit/steps/commit_and_push.md
+++ b/.deepwork/jobs/commit/steps/commit_and_push.md
@@ -78,14 +78,11 @@ Check the list of changed files against what was modified during this session, e
 
 ## Quality Criteria
 
-- Changed files list was reviewed by the agent
-- Files match what was modified during this session (or unexpected changes were investigated and handled)
-- CHANGELOG.md was updated with entries in the `[Unreleased]` section (if changes warrant documentation)
-- Version numbers were NOT modified (in pyproject.toml or CHANGELOG.md version headers)
-- Commit message follows project conventions
-- Commit was created successfully
+- Changed files were verified against expectations
+- CHANGELOG.md was updated with entries in [Unreleased] section (if changes warrant documentation)
+- Version numbers were NOT modified (pyproject.toml version and CHANGELOG version headers unchanged)
+- Commit was created with appropriate message
 - Changes were pushed to remote
-- When all criteria are met, include `<promise>✓ Quality Criteria Met</promise>` in your response
 
 ## Context
 

--- a/.deepwork/jobs/commit/steps/lint.md
+++ b/.deepwork/jobs/commit/steps/lint.md
@@ -63,9 +63,7 @@ Report the results of each command.
 
 - ruff format was run successfully
 - ruff check was run with --fix flag
-- No remaining lint errors (or all are documented and intentional)
-- Sub-agent was used to conserve context
-- When all criteria are met, include `<promise>✓ Quality Criteria Met</promise>` in your response
+- No remaining lint errors
 
 ## Context
 

--- a/.deepwork/jobs/commit/steps/review.md
+++ b/.deepwork/jobs/commit/steps/review.md
@@ -94,11 +94,8 @@ If no issues are found in a category, state that explicitly.
 ## Quality Criteria
 
 - Changed files were identified
-- Sub-agent reviewed all changed files
-- Issues were categorized (general, DRY, naming, tests)
+- Sub-agent reviewed the code for general issues, DRY opportunities, naming clarity, and test coverage
 - All identified issues were addressed or documented as intentional
-- Sub-agent was used to conserve context
-- When all criteria are met, include `<promise>✓ Quality Criteria Met</promise>` in your response
 
 ## Context
 

--- a/.deepwork/jobs/commit/steps/test.md
+++ b/.deepwork/jobs/commit/steps/test.md
@@ -44,9 +44,7 @@ Execute the test suite for the project and iteratively fix any failures until al
 ## Quality Criteria
 
 - Latest code was pulled from the branch
-- Test command was correctly identified or used from input
-- All tests are now passing
-- When all criteria are met, include `<promise>✓ Quality Criteria Met</promise>` in your response
+- All tests are passing
 
 ## Context
 


### PR DESCRIPTION
## Summary
Refactored the commit job workflow to use a cleaner `quality_criteria` approach instead of `hooks.after_agent` for step validation. This improves code maintainability and provides a more declarative way to specify validation requirements.

## Key Changes
- **Version bump**: Updated job version from 1.4.0 to 1.5.0
- **Validation mechanism**: Replaced `hooks.after_agent` prompts with `quality_criteria` lists across all four workflow steps:
  - `review`: 3 criteria for code review validation
  - `test`: 2 criteria for test execution validation
  - `lint`: 3 criteria for linting validation
  - `commit_and_push`: 5 criteria for commit validation
- **Documentation updates**: Synchronized quality criteria in step markdown files (review.md, test.md, lint.md, commit_and_push.md) to match the job configuration
- **Simplified criteria**: Removed redundant or implementation-specific details (e.g., "sub-agent was used to conserve context", promise tags) to focus on outcome-based validation
- **Input cleanup**: Removed unused `test_command` input from the test step

## Implementation Details
The refactoring maintains the same validation intent while providing a more structured format. Quality criteria are now:
- Declaratively listed as simple strings rather than embedded in prompt text
- Easier to parse and validate programmatically
- More consistent across the workflow
- Clearer for users to understand what constitutes successful step completion

All step documentation has been updated to reflect the new quality criteria format, removing references to promise tags and focusing on the actual validation requirements.

https://claude.ai/code/session_01JfPmbjHD1JaRV95DY83nUr