### PR TITLE
Fix YAML formatting in SKILL.md files and Jinja templates

### DIFF
--- a/.claude/skills/add_platform.add_capabilities/SKILL.md
+++ b/.claude/skills/add_platform.add_capabilities/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: add_platform.add_capabilities
-description: "Updates job schema and adapters with any new hook events the platform supports. Use after research to extend DeepWork's hook system."user-invocable: false---
+description: "Updates job schema and adapters with any new hook events the platform supports. Use after research to extend DeepWork's hook system."
+user-invocable: false
+---
 
 # add_platform.add_capabilities
 

--- a/.claude/skills/add_platform.implement/SKILL.md
+++ b/.claude/skills/add_platform.implement/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: add_platform.implement
-description: "Creates platform adapter, templates, tests with 100% coverage, and README documentation. Use after adding hook capabilities."user-invocable: falsehooks:  Stop:
-    - hooks:        - type: command
-          command: ".deepwork/jobs/add_platform/hooks/run_tests.sh"  SubagentStop:
-    - hooks:        - type: command
-          command: ".deepwork/jobs/add_platform/hooks/run_tests.sh"---
+description: "Creates platform adapter, templates, tests with 100% coverage, and README documentation. Use after adding hook capabilities."
+user-invocable: false
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: ".deepwork/jobs/add_platform/hooks/run_tests.sh"
+  SubagentStop:
+    - hooks:
+        - type: command
+          command: ".deepwork/jobs/add_platform/hooks/run_tests.sh"
+---
 
 # add_platform.implement
 

--- a/.claude/skills/add_platform.research/SKILL.md
+++ b/.claude/skills/add_platform.research/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: add_platform.research
-description: "Captures CLI configuration and hooks system documentation for the new platform. Use when starting platform integration."user-invocable: false---
+description: "Captures CLI configuration and hooks system documentation for the new platform. Use when starting platform integration."
+user-invocable: false
+---
 
 # add_platform.research
 

--- a/.claude/skills/add_platform.verify/SKILL.md
+++ b/.claude/skills/add_platform.verify/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: add_platform.verify
-description: "Sets up platform directories and verifies deepwork install works correctly. Use after implementation to confirm integration."user-invocable: false---
+description: "Sets up platform directories and verifies deepwork install works correctly. Use after implementation to confirm integration."
+user-invocable: false
+---
 
 # add_platform.verify
 

--- a/.claude/skills/commit.commit_and_push/SKILL.md
+++ b/.claude/skills/commit.commit_and_push/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit.commit_and_push
-description: "Verifies changed files, creates commit, and pushes to remote. Use after linting passes to finalize changes."user-invocable: false---
+description: "Verifies changed files, creates commit, and pushes to remote. Use after linting passes to finalize changes."
+user-invocable: false
+---
 
 # commit.commit_and_push
 

--- a/.claude/skills/commit.lint/SKILL.md
+++ b/.claude/skills/commit.lint/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit.lint
-description: "Formats and lints code with ruff using a sub-agent. Use after tests pass to ensure code style compliance."user-invocable: false---
+description: "Formats and lints code with ruff using a sub-agent. Use after tests pass to ensure code style compliance."
+user-invocable: false
+---
 
 # commit.lint
 

--- a/.claude/skills/commit.review/SKILL.md
+++ b/.claude/skills/commit.review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit.review
-description: "Reviews changed code for issues, DRY opportunities, naming clarity, and test coverage using a sub-agent. Use as the first step before testing."user-invocable: false---
+description: "Reviews changed code for issues, DRY opportunities, naming clarity, and test coverage using a sub-agent. Use as the first step before testing."
+user-invocable: false
+---
 
 # commit.review
 

--- a/.claude/skills/commit.test/SKILL.md
+++ b/.claude/skills/commit.test/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit.test
-description: "Pulls latest code and runs tests until all pass. Use after code review passes to verify changes work correctly."user-invocable: false---
+description: "Pulls latest code and runs tests until all pass. Use after code review passes to verify changes work correctly."
+user-invocable: false
+---
 
 # commit.test
 

--- a/.claude/skills/deepwork_jobs.define/SKILL.md
+++ b/.claude/skills/deepwork_jobs.define/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deepwork_jobs.define
-description: "Creates a job.yml specification by gathering workflow requirements through structured questions. Use when starting a new multi-step workflow."user-invocable: false---
+description: "Creates a job.yml specification by gathering workflow requirements through structured questions. Use when starting a new multi-step workflow."
+user-invocable: false
+---
 
 # deepwork_jobs.define
 

--- a/.claude/skills/deepwork_jobs.implement/SKILL.md
+++ b/.claude/skills/deepwork_jobs.implement/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deepwork_jobs.implement
-description: "Generates step instruction files and syncs slash commands from the job.yml specification. Use after job spec review passes."user-invocable: false---
+description: "Generates step instruction files and syncs slash commands from the job.yml specification. Use after job spec review passes."
+user-invocable: false
+---
 
 # deepwork_jobs.implement
 

--- a/.claude/skills/deepwork_jobs.learn/SKILL.md
+++ b/.claude/skills/deepwork_jobs.learn/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deepwork_jobs.learn
-description: "Analyzes conversation history to improve job instructions and capture learnings. Use after running a job to refine it."---
+description: "Analyzes conversation history to improve job instructions and capture learnings. Use after running a job to refine it."
+---
 
 # deepwork_jobs.learn
 

--- a/.claude/skills/deepwork_jobs.review_job_spec/SKILL.md
+++ b/.claude/skills/deepwork_jobs.review_job_spec/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deepwork_jobs.review_job_spec
-description: "Reviews job.yml against quality criteria using a sub-agent for unbiased validation. Use after defining a job specification."user-invocable: false---
+description: "Reviews job.yml against quality criteria using a sub-agent for unbiased validation. Use after defining a job specification."
+user-invocable: false
+---
 
 # deepwork_jobs.review_job_spec
 

--- a/.claude/skills/deepwork_rules.define/SKILL.md
+++ b/.claude/skills/deepwork_rules.define/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deepwork_rules.define
-description: "Creates a rule file that triggers when specified files change. Use when setting up documentation sync, code review requirements, or automated commands."user-invocable: false---
+description: "Creates a rule file that triggers when specified files change. Use when setting up documentation sync, code review requirements, or automated commands."
+user-invocable: false
+---
 
 # deepwork_rules.define
 

--- a/.claude/skills/manual_tests.infinite_block_tests/SKILL.md
+++ b/.claude/skills/manual_tests.infinite_block_tests/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: manual_tests.infinite_block_tests
-description: "Runs all 4 infinite block tests serially. Tests both 'should fire' (no promise) and 'should NOT fire' (with promise) scenarios."user-invocable: false---
+description: "Runs all 4 infinite block tests serially. Tests both 'should fire' (no promise) and 'should NOT fire' (with promise) scenarios."
+user-invocable: false
+---
 
 # manual_tests.infinite_block_tests
 

--- a/.claude/skills/manual_tests.reset/SKILL.md
+++ b/.claude/skills/manual_tests.reset/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: manual_tests.reset
-description: "Runs FIRST to ensure clean environment. Also called internally by other steps when they need to revert changes and clear the queue."user-invocable: false---
+description: "Runs FIRST to ensure clean environment. Also called internally by other steps when they need to revert changes and clear the queue."
+user-invocable: false
+---
 
 # manual_tests.reset
 

--- a/.claude/skills/manual_tests.run_fire_tests/SKILL.md
+++ b/.claude/skills/manual_tests.run_fire_tests/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: manual_tests.run_fire_tests
-description: "Runs all 6 'should fire' tests serially with resets between each. Use after NOT-fire tests to verify rules fire correctly."user-invocable: false---
+description: "Runs all 6 'should fire' tests serially with resets between each. Use after NOT-fire tests to verify rules fire correctly."
+user-invocable: false
+---
 
 # manual_tests.run_fire_tests
 

--- a/.claude/skills/manual_tests.run_not_fire_tests/SKILL.md
+++ b/.claude/skills/manual_tests.run_not_fire_tests/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: manual_tests.run_not_fire_tests
-description: "Runs all 6 'should NOT fire' tests in parallel sub-agents. Use to verify rules don't fire when safety conditions are met."user-invocable: false---
+description: "Runs all 6 'should NOT fire' tests in parallel sub-agents. Use to verify rules don't fire when safety conditions are met."
+user-invocable: false
+---
 
 # manual_tests.run_not_fire_tests
 

--- a/.claude/skills/update.job/SKILL.md
+++ b/.claude/skills/update.job/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: update.job
-description: "Edits standard job source files in src/ and runs deepwork install to sync changes. Use when updating job.yml or step instructions."user-invocable: false---
+description: "Edits standard job source files in src/ and runs deepwork install to sync changes. Use when updating job.yml or step instructions."
+user-invocable: false
+---
 
 # update.job
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SessionStart hook now skips non-initial sessions (resume, compact/clear) by checking the `source` field in stdin JSON, reducing noise and redundant checks
 
 ### Fixed
+- Fixed skill template generating malformed YAML frontmatter with fields concatenated on single lines
+  - Removed over-aggressive `{%-` whitespace stripping from Jinja template
+  - Fields like `user-invocable` and `hooks` now render on proper separate lines
+  - Affects `src/deepwork/templates/claude/skill-job-step.md.jinja`
 
 ### Removed
+
 ## [0.5.1] - 2026-01-24
 
 ### Added

--- a/src/deepwork/templates/claude/skill-job-step.md.jinja
+++ b/src/deepwork/templates/claude/skill-job-step.md.jinja
@@ -48,10 +48,10 @@ Template Variables:
 ---
 name: {{ job_name }}.{{ step_id }}
 description: "{{ step_description }}"
-{%- if not exposed %}
+{% if not exposed %}
 user-invocable: false
-{%- endif %}{#- if not exposed #}
-{#-
+{% endif %}{#- if not exposed #}
+{#
   NOTE: Prompt-based stop hooks do not currently work in Claude Code.
   See: https://github.com/anthropics/claude-code/issues/20221
   Only command/script hooks are generated here. Prompt hooks are filtered out.
@@ -68,7 +68,7 @@ user-invocable: false
 {%- endfor -%}{#- for event_name, event_hooks in hooks.items() #}
 {%- if has_command_hooks.value %}
 hooks:
-{%- for event_name, event_hooks in hooks.items() %}
+{% for event_name, event_hooks in hooks.items() %}
 {%- set script_hooks = event_hooks | selectattr("type", "equalto", "script") | list %}
 {%- if script_hooks -%}
 {#- For Stop events, generate both Stop and SubagentStop blocks #}
@@ -76,19 +76,19 @@ hooks:
 {%- for stop_event in ["Stop", "SubagentStop"] %}
   {{ stop_event }}:
     - hooks:
-{%- for hook in script_hooks %}
+{% for hook in script_hooks %}
         - type: command
           command: ".deepwork/jobs/{{ job_name }}/{{ hook.path }}"
-{%- endfor %}{#- for hook in script_hooks #}
-{%- endfor %}{#- for stop_event in ["Stop", "SubagentStop"] #}
+{% endfor %}{#- for hook in script_hooks #}
+{% endfor %}{#- for stop_event in ["Stop", "SubagentStop"] #}
 {%- elif event_name != "SubagentStop" or "Stop" not in hooks %}
   {{ event_name }}:
     - hooks:
-{%- for hook in script_hooks %}
+{% for hook in script_hooks %}
         - type: command
           command: ".deepwork/jobs/{{ job_name }}/{{ hook.path }}"
-{%- endfor %}{#- for hook in script_hooks #}
-{%- endif %}{#- if event_name == "Stop" #}
+{% endfor %}{#- for hook in script_hooks #}
+{% endif %}{#- if event_name == "Stop" #}
 {%- endif %}{#- if script_hooks #}
 {%- endfor %}{#- for event_name, event_hooks in hooks.items() #}
 {%- endif %}{#- if has_command_hooks.value #}


### PR DESCRIPTION
## Summary
This PR fixes YAML formatting issues across skill definition files and Jinja templates to ensure proper parsing and readability.

## Key Changes
- **SKILL.md files**: Fixed malformed YAML frontmatter by adding proper line breaks between metadata fields
  - Separated `description` and `user-invocable` fields onto distinct lines
  - Fixed `add_platform.implement` which had severely malformed YAML with hooks configuration on single lines
  - Applied consistent formatting across all 16 skill files in `.claude/skills/`

- **Jinja template**: Improved whitespace control in `skill-job-step.md.jinja`
  - Changed `{%- if` to `{% if` for better readability where appropriate
  - Adjusted comment syntax from `{#-` to `{#` for consistency
  - Maintained proper indentation in generated YAML output for hooks configuration

## Implementation Details
The changes ensure that:
1. YAML frontmatter in all SKILL.md files is valid and parseable
2. Generated skill files from the Jinja template will have properly formatted YAML
3. Hooks configuration (particularly in `add_platform.implement`) is correctly structured with proper nesting
4. Template output maintains consistent indentation for readability

https://claude.ai/code/session_01DmwZm5TgeeoR4sxp7GBtBE