### PR TITLE
Remove reload instructions from skill sync output

### DIFF
--- a/src/deepwork/cli/sync.py
+++ b/src/deepwork/cli/sync.py
@@ -117,7 +117,6 @@ def sync_skills(project_path: Path) -> None:
     # Sync each platform
     generator = SkillGenerator()
     stats = {"platforms": 0, "skills": 0, "hooks": 0}
-    synced_adapters: list[AgentAdapter] = []
 
     for platform_name in platforms:
         try:
@@ -184,7 +183,6 @@ def sync_skills(project_path: Path) -> None:
                 console.print(f"    [red]✗[/red] Failed to sync skill permissions: {e}")
 
         stats["platforms"] += 1
-        synced_adapters.append(adapter)
 
     # Summary
     console.print()
@@ -202,10 +200,3 @@ def sync_skills(project_path: Path) -> None:
 
     console.print(table)
     console.print()
-
-    # Show reload instructions for each synced platform
-    if synced_adapters and stats["skills"] > 0:
-        console.print("[bold]To use the new skills:[/bold]")
-        for adapter in synced_adapters:
-            console.print(f"  [cyan]{adapter.display_name}:[/cyan] {adapter.reload_instructions}")
-        console.print()

--- a/src/deepwork/core/adapters.py
+++ b/src/deepwork/core/adapters.py
@@ -58,10 +58,6 @@ class AgentAdapter(ABC):
     skill_template: ClassVar[str] = "skill-job-step.md.jinja"
     meta_skill_template: ClassVar[str] = "skill-job-meta.md.jinja"
 
-    # Instructions for reloading skills after sync (shown to users)
-    # Subclasses should override with platform-specific instructions.
-    reload_instructions: ClassVar[str] = "Restart your AI assistant session to use the new skills."
-
     # Mapping from generic SkillLifecycleHook to platform-specific event names.
     # Subclasses should override this to provide platform-specific mappings.
     hook_name_mapping: ClassVar[dict[SkillLifecycleHook, str]] = {}
@@ -295,12 +291,6 @@ class ClaudeAdapter(AgentAdapter):
     name = "claude"
     display_name = "Claude Code"
     config_dir = ".claude"
-
-    # Claude Code doesn't have a reload command - must restart session
-    reload_instructions: ClassVar[str] = (
-        "Type 'exit' to leave your current session, then run "
-        "'claude --resume' (your history will be maintained)."
-    )
 
     # Claude Code uses PascalCase event names
     hook_name_mapping: ClassVar[dict[SkillLifecycleHook, str]] = {
@@ -575,11 +565,6 @@ class GeminiAdapter(AgentAdapter):
     config_dir = ".gemini"
     skill_template = "skill-job-step.toml.jinja"
     meta_skill_template = "skill-job-meta.toml.jinja"
-
-    # Gemini CLI can reload with /memory refresh
-    reload_instructions: ClassVar[str] = (
-        "Run '/memory refresh' to reload skills, or restart your Gemini CLI session."
-    )
 
     # Gemini CLI does NOT support skill-level hooks
     # Hooks are global/project-level in settings.json, not per-skill

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/implement.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/implement.md
@@ -126,11 +126,7 @@ This will:
 - Generate skills for each step
 - Make the skills available in `.claude/skills/` (or appropriate platform directory)
 
-### Step 6: Relay Reload Instructions
-
-After running `deepwork sync`, look at the "To use the new skills" section in the output. **Relay these exact reload instructions to the user** so they know how to pick up the new skills. Don't just reference the sync output - tell them directly what they need to do (e.g., "Type 'exit' then run 'claude --resume'" for Claude Code, or "Run '/memory refresh'" for Gemini CLI).
-
-### Step 7: Consider Rules for the New Job
+### Step 6: Consider Rules for the New Job
 
 After implementing the job, consider whether there are **rules** that would help enforce quality or consistency when working with this job's domain.
 
@@ -221,8 +217,7 @@ Before marking this step complete, ensure:
 - [ ] Each instruction file is complete and actionable
 - [ ] `deepwork sync` executed successfully
 - [ ] Skills generated in platform directory
-- [ ] User informed to follow reload instructions from `deepwork sync`
-- [ ] Considered whether rules would benefit this job (Step 7)
+- [ ] Considered whether rules would benefit this job (Step 6)
 - [ ] If rules suggested, offered to run `/deepwork_rules.define`
 
 ## Quality Criteria

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/learn.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/learn.md
@@ -233,14 +233,12 @@ If instruction files were modified:
      changes: "Improved [step] instructions based on execution learnings: [brief description]"
    ```
 
-### Step 7: Sync and Relay Instructions
+### Step 7: Sync Skills
 
-1. **Run deepwork sync** (if instructions were modified)
-   ```bash
-   deepwork sync
-   ```
-
-2. **If skills were regenerated**, look at the "To use the new skills" section in the `deepwork sync` output and **relay these exact reload instructions to the user** (e.g., "Type 'exit' then run 'claude --resume'" for Claude Code)
+**Run deepwork sync** (if instructions were modified)
+```bash
+deepwork sync
+```
 
 ## File Reference Patterns
 
@@ -330,7 +328,7 @@ I found the following job executions:
 
 **Summary**
 
-Updated job instructions and created AGENTS.md with bespoke learnings. To get the updated skills, type 'exit' then run 'claude --resume'.
+Updated job instructions and created AGENTS.md with bespoke learnings.
 ```
 
 ## Handling Edge Cases


### PR DESCRIPTION
## Summary
This PR removes the platform-specific reload instructions that were displayed to users after running `deepwork sync`. The instructions are being removed from both the CLI output and the adapter class definitions, along with related documentation updates.

## Key Changes

- **CLI Changes**: Removed the "To use the new skills" section from `sync_skills()` that displayed reload instructions for each synced platform
- **Adapter Changes**: Removed `reload_instructions` class variable from `AgentAdapter` base class and platform-specific implementations (`ClaudeAdapter`, `GeminiAdapter`)
- **Documentation Updates**: 
  - Removed Step 6 ("Relay Reload Instructions") from the implement job workflow
  - Simplified Step 7 ("Sync and Relay Instructions") in the learn job to just "Sync Skills"
  - Removed references to relaying reload instructions in example outputs and checklists
  - Updated completion checklist to reflect the removed step

## Rationale
This change simplifies the user experience by removing the need to display and relay platform-specific reload instructions after syncing skills. Users will need to discover or know the reload process for their respective platforms independently.

## Files Modified
- `src/deepwork/cli/sync.py`
- `src/deepwork/core/adapters.py`
- `src/deepwork/standard_jobs/deepwork_jobs/steps/implement.md`
- `src/deepwork/standard_jobs/deepwork_jobs/steps/learn.md`

https://claude.ai/code/session_01FD9ALAxSQ6x4QWHqXJiJJR