### PR TITLE
chore: Add script to test Homebrew formula with local build

### DIFF
--- a/scripts/test-homebrew.sh
+++ b/scripts/test-homebrew.sh
@@ -38,21 +38,24 @@ echo "==> Built deepwork-$VERSION"
 echo "    Tarball: $TARBALL_PATH"
 echo "    SHA256:  $SHA256"
 
-# Create a temporary formula pointing to the local tarball
-TEMP_DIR=$(mktemp -d)
-TEMP_FORMULA="$TEMP_DIR/deepwork.rb"
-trap "rm -rf $TEMP_DIR" EXIT
+# Set up a local tap with the modified formula
+TAP_NAME="local/deepwork-test"
+TAP_DIR="$(brew --repository)/Library/Taps/local/homebrew-deepwork-test"
+
+echo "==> Setting up local tap..."
+brew untap "$TAP_NAME" 2>/dev/null || true
+brew tap-new --no-git "$TAP_NAME"
 
 sed -e "s|url \"https://.*\"|url \"file://$TARBALL_PATH\"|" \
     -e "s|sha256 \".*\"|sha256 \"$SHA256\"|" \
-    "$HOMEBREW_TAP/Formula/deepwork.rb" > "$TEMP_FORMULA"
+    "$HOMEBREW_TAP/Formula/deepwork.rb" > "$TAP_DIR/Formula/deepwork.rb"
 
 echo "==> Installing from local build..."
 brew uninstall deepwork 2>/dev/null || true
-brew install --formula --verbose "$TEMP_FORMULA"
+brew install --verbose "$TAP_NAME/deepwork"
 
 echo "==> Running brew test..."
-brew test deepwork
+brew test "$TAP_NAME/deepwork"
 
 echo "==> Verifying binary..."
 deepwork --version


### PR DESCRIPTION
## Summary
- Adds `scripts/test-homebrew.sh` for testing the Homebrew formula against unreleased deepwork changes
- Builds an sdist tarball from local source, creates a temporary formula pointing to it, and runs `brew install`/`brew test`
- Defaults to sibling `../homebrew-deepwork` directory for the tap location

## Test plan
- [ ] Run `./scripts/test-homebrew.sh` with homebrew-deepwork cloned as sibling directory
- [ ] Verify it builds tarball, installs via Homebrew, and runs tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)