### PR TITLE
docs: add note that project folder must be a Git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Triage email, give feedback to your team, make tutorials/documentation, QA your 
 brew tap unsupervisedcom/deepwork && brew install deepwork
 ```
 
-Then in your project folder:
+Then in your project folder (must be a Git repository):
 ```bash
 deepwork install
 claude
 ```
+
+> **Note:** DeepWork requires a Git repository. If your folder isn't already a repo, run `git init` first.
 
 Now inside claude, define your first job using the `/deepwork_jobs` command. Ex.
 ```
@@ -81,11 +83,13 @@ brew tap unsupervisedcom/deepwork
 brew install deepwork
 ```
 
-Then in any project folder:
+Then in any project folder (must be a Git repository):
 
 ```bash
 deepwork install
 ```
+
+> **Note:** If your folder isn't a Git repo yet, run `git init` first.
 
 **After install, load Claude.** Then verify you see this command: `/deepwork_jobs`
 


### PR DESCRIPTION
## Summary
- Added a note to the Install section clarifying that `deepwork install` requires a Git repository
- Added the same note to the Quick Start section for consistency
- Suggests running `git init` first if the folder isn't already a repo

This addresses a common point of confusion for new users who try to run `deepwork install` in a non-Git folder and get an error.

## Test plan
- [x] Verified the README renders correctly with the new notes