### PR TITLE
Add plugin marketplace for learning-agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "deepwork-plugins",
+  "version": "1.0.0",
+  "description": "Plugins for the DeepWork framework",
+  "owner": {
+    "name": "DeepWork",
+    "email": "noah@unsupervised.com"
+  },
+  "plugins": [
+    {
+      "name": "learning-agents",
+      "description": "Auto-improving AI sub-agents that learn from their mistakes across sessions",
+      "version": "0.1.0",
+      "source": "./learning_agents",
+      "author": {
+        "name": "DeepWork"
+      },
+      "category": "learning",
+      "keywords": ["agents", "learning", "self-improving", "sub-agents"],
+      "repository": "https://github.com/Unsupervisedcom/deepwork",
+      "license": "MIT"
+    }
+  ]
+}

--- a/CLAUDE_PLUGINS_README.md
+++ b/CLAUDE_PLUGINS_README.md
@@ -1,0 +1,27 @@
+# DeepWork Claude Code Plugins
+
+This repository includes a Claude Code plugin marketplace with reusable plugins for AI-powered workflows.
+
+## Available Plugins
+
+| Plugin | Description |
+|--------|-------------|
+| **learning-agents** | Auto-improving AI sub-agents that learn from their mistakes across sessions |
+
+## Installation
+
+```
+# Add the marketplace
+/plugin marketplace add https://github.com/Unsupervisedcom/deepwork
+
+# Install the learning-agents plugin
+/plugin install learning-agents@deepwork-plugins
+
+# Verify installation
+/plugin list
+```
+
+## Learn More
+
+- [Learning Agents architecture](doc/learning_agents_architecture.md)
+- [Claude Code plugin docs](https://docs.anthropic.com/en/docs/claude-code/plugins)


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` listing the learning-agents plugin
- Add `CLAUDE_PLUGINS_README.md` with installation instructions

## Test plan
- [ ] Verify `marketplace.json` schema is valid
- [ ] Confirm `/plugin marketplace add` works with this repo URL
- [ ] Confirm `/plugin install learning-agents@deepwork-plugins` installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)