### PR TITLE
Enable learning-agents plugin and improve install docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,5 +119,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "learning-agents@deepwork-plugins": true
   }
 }

--- a/CLAUDE_PLUGINS_README.md
+++ b/CLAUDE_PLUGINS_README.md
@@ -9,16 +9,16 @@ This repository includes a Claude Code plugin marketplace with reusable plugins 
 | **learning-agents** | Auto-improving AI sub-agents that learn from their mistakes across sessions |
 
 ## Installation
+Run the following *in Claude*.
 
+### Add the marketplace
 ```
-# Add the marketplace
 /plugin marketplace add https://github.com/Unsupervisedcom/deepwork
+```
 
-# Install the learning-agents plugin
+### Install the learning-agents plugin
+```
 /plugin install learning-agents@deepwork-plugins
-
-# Verify installation
-/plugin list
 ```
 
 ## Learn More


### PR DESCRIPTION
## Summary
- Pre-enables the `learning-agents` plugin in `.claude/settings.json` so contributors get it automatically
- Simplifies plugin install instructions in `CLAUDE_PLUGINS_README.md` with clearer formatting

## Test plan
- [ ] Verify `learning-agents` plugin loads on fresh clone
- [ ] Confirm README install steps work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)