### PR TITLE
Add domain prefixes to REQ IDs for unambiguous traceability

### DIFF
--- a/.claude/agents/requirements_reviewer.md
+++ b/.claude/agents/requirements_reviewer.md
@@ -21,18 +21,34 @@ You review the project to verify that its three-way traceability chain is mainta
 
 ## Project Conventions
 
-This project uses formal requirements documents with RFC 2119 keywords (MUST, SHALL, SHOULD, MAY, etc.) located in the `requirements/` directory. Each file follows the naming pattern `REQ-NNN-<topic>.md` and contains individually numbered requirements like `REQ-001.1`, `REQ-001.2`, etc.
+This project uses formal requirements documents with RFC 2119 keywords (MUST, SHALL, SHOULD, MAY, etc.) located in the `specs/` directory. Specs are organized into domain subdirectories:
 
-Every piece of end-user functionality MUST be documented as a formal requirement. Every requirement MUST have a corresponding automated test that explicitly references it. Tests MUST NOT be modified unless the underlying requirement has changed.
+- `specs/deepwork/` — root DeepWork specs (DW-REQ-005, 006, 007, 010)
+- `specs/deepwork/jobs/` — job-related specs (JOBS-REQ-001, 002, 003, 004, 008, 009)
+- `specs/deepwork/review/` — review-related specs (REVIEW-REQ-001 through 008)
+- `specs/learning-agents/` — learning agent specs (LA-REQ-001 through 012)
+
+Each file follows the naming pattern `{PREFIX}-REQ-NNN-<topic>.md`, where the prefix identifies the domain:
+
+| Prefix | Domain |
+|--------|--------|
+| `DW-REQ` | deepwork root |
+| `JOBS-REQ` | deepwork/jobs |
+| `REVIEW-REQ` | deepwork/review |
+| `LA-REQ` | learning-agents |
+
+Each domain maintains its own independent REQ numbering sequence. Files contain individually numbered sub-requirements like `JOBS-REQ-004.1`, `JOBS-REQ-004.2`, etc.
+
+Every piece of end-user functionality MUST be documented as a formal requirement. Every requirement MUST have a corresponding automated test that explicitly references it using the fully qualified REQ ID. Tests MUST NOT be modified unless the underlying requirement has changed.
 
 ## Traceability Format
 
 Tests reference requirements using two mechanisms:
 
-1. **Module-level docstrings** — e.g. `"""Tests for ClaudeInvocation — validates REQ-004."""`
+1. **Module-level docstrings** — e.g. `"""Tests for ClaudeInvocation — validates JOBS-REQ-004."""`
 2. **Per-test traceability comments** — placed directly above each test method:
    ```python
-   # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5).
+   # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5).
    # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
    def test_system_prompt_text_and_file_mutually_exclusive(self, tmp_path):
        ...
@@ -45,7 +61,7 @@ When asked to review, perform these checks:
 ### 1. Requirements Coverage
 
 For every piece of new or changed end-user functionality in the diff:
-- Verify there is a corresponding requirement in `requirements/REQ-*.md`
+- Verify there is a corresponding requirement in `specs/**/*-REQ-*.md`
 - If functionality is new, check that a new requirement was added
 - If functionality changed, check that the relevant requirement was updated
 - Flag any functional code changes that lack a matching requirement

--- a/specs/deepwork/DW-REQ-005-cli-commands.md
+++ b/specs/deepwork/DW-REQ-005-cli-commands.md
@@ -1,4 +1,4 @@
-# REQ-005: CLI Commands
+# DW-REQ-005: CLI Commands
 
 ## Overview
 
@@ -6,14 +6,14 @@ The DeepWork CLI provides two primary commands: `serve` (starts the MCP server) 
 
 ## Requirements
 
-### REQ-005.1: CLI Entry Point
+### DW-REQ-005.1: CLI Entry Point
 
 1. The CLI MUST be a Click group command named `cli`.
 2. The CLI MUST provide a `--version` option sourced from the `deepwork` package version.
 3. The CLI MUST register `serve`, `hook`, `install`, and `sync` as subcommands.
 4. The CLI MUST be callable as `deepwork` from the command line (via package entry point).
 
-### REQ-005.2: serve Command
+### DW-REQ-005.2: serve Command
 
 1. The `serve` command MUST be a Click command.
 2. The `serve` command MUST accept a `--path` option (default: `"."`, must exist, must be a directory).
@@ -28,7 +28,7 @@ The DeepWork CLI provides two primary commands: `serve` (starts the MCP server) 
 11. The `serve` command MUST catch `ServeError` and print a user-friendly error message to stderr, then abort.
 12. The `serve` command MUST propagate other unexpected exceptions.
 
-### REQ-005.3: hook Command
+### DW-REQ-005.3: hook Command
 
 1. The `hook` command MUST be a Click command.
 2. The `hook` command MUST accept a single positional argument `HOOK_NAME`.
@@ -42,7 +42,7 @@ The DeepWork CLI provides two primary commands: `serve` (starts the MCP server) 
 10. `HookError` exceptions MUST be caught and printed to stderr with exit code 1.
 11. Other unexpected exceptions MUST be caught and printed to stderr with exit code 1.
 
-### REQ-005.4: Deprecated install and sync Commands
+### DW-REQ-005.4: Deprecated install and sync Commands
 
 > **SCHEDULED REMOVAL: June 1st, 2026; details in PR https://github.com/Unsupervisedcom/deepwork/pull/227.** These commands exist only for
 > backwards compatibility with users who installed DeepWork globally via

--- a/specs/deepwork/DW-REQ-006-hook-wrapper-system.md
+++ b/specs/deepwork/DW-REQ-006-hook-wrapper-system.md
@@ -1,4 +1,4 @@
-# REQ-006: Hook Wrapper System
+# DW-REQ-006: Hook Wrapper System
 
 ## Overview
 
@@ -6,12 +6,12 @@ The hook wrapper system provides cross-platform compatibility for hooks running 
 
 ## Requirements
 
-### REQ-006.1: Supported Platforms
+### DW-REQ-006.1: Supported Platforms
 
 1. The system MUST support the following platforms as a `Platform` enum: `CLAUDE` (`"claude"`) and `GEMINI` (`"gemini"`).
 2. The `Platform` enum MUST be a `StrEnum` for string serialization.
 
-### REQ-006.2: Event Normalization
+### DW-REQ-006.2: Event Normalization
 
 1. The system MUST define a `NormalizedEvent` enum with the following values: `AFTER_AGENT`, `BEFORE_TOOL`, `BEFORE_PROMPT`, `SESSION_START`, `SESSION_END`, `AFTER_TOOL`, `BEFORE_MODEL`, `AFTER_MODEL`.
 2. The `NormalizedEvent` enum MUST be a `StrEnum`.
@@ -41,7 +41,7 @@ The hook wrapper system provides cross-platform compatibility for hooks running 
 
 18. The system MUST maintain reverse mappings (`NORMALIZED_TO_EVENT`) for converting normalized events back to platform-specific names.
 
-### REQ-006.3: Tool Name Normalization
+### DW-REQ-006.3: Tool Name Normalization
 
 1. Tool names MUST be normalized to snake_case.
 
@@ -69,7 +69,7 @@ The hook wrapper system provides cross-platform compatibility for hooks running 
 
 13. The system MUST maintain reverse mappings (`NORMALIZED_TO_TOOL`) for converting normalized tool names back to platform-specific names.
 
-### REQ-006.4: HookInput Normalization
+### DW-REQ-006.4: HookInput Normalization
 
 1. `HookInput` MUST be a dataclass with fields: `platform`, `event`, `session_id`, `transcript_path`, `cwd`, `tool_name`, `tool_input`, `tool_response`, `prompt`, `raw_input`.
 2. `HookInput.from_dict()` MUST extract `hook_event_name` from the raw input and normalize it via `EVENT_TO_NORMALIZED`.
@@ -78,7 +78,7 @@ The hook wrapper system provides cross-platform compatibility for hooks running 
 5. `HookInput.from_dict()` MUST preserve the original raw input in the `raw_input` field.
 6. `normalize_input()` MUST parse JSON from a raw string, defaulting to an empty dict on empty input or JSON decode error.
 
-### REQ-006.5: HookOutput Denormalization
+### DW-REQ-006.5: HookOutput Denormalization
 
 1. `HookOutput` MUST be a dataclass with fields: `decision`, `reason`, `context`, `continue_loop` (default: True), `stop_reason`, `suppress_output` (default: False), `raw_output`.
 2. When `decision` is empty, the output dict MUST NOT contain a `decision` key.
@@ -89,31 +89,31 @@ The hook wrapper system provides cross-platform compatibility for hooks running 
 7. When `continue_loop` is `False` and `stop_reason` is non-empty, the output MUST include `"stopReason"`.
 8. When `suppress_output` is `True`, the output MUST include `"suppressOutput": true`.
 
-### REQ-006.6: Context Output (Platform-Specific)
+### DW-REQ-006.6: Context Output (Platform-Specific)
 
 1. On Claude for `SESSION_START` events, context MUST be set via `hookSpecificOutput.additionalContext` with `hookEventName` set to the platform-specific event name.
 2. On Claude for all other events, context MUST be set via `systemMessage`.
 3. On Gemini for all events, context MUST be set via `hookSpecificOutput.additionalContext` with `hookEventName`.
 
-### REQ-006.7: Output Serialization
+### DW-REQ-006.7: Output Serialization
 
 1. `denormalize_output()` MUST convert a `HookOutput` to a platform-specific JSON string.
 2. If the output dict is empty (no decision, no reason, no context, etc.), the result MUST be `"{}"`.
 3. Raw output fields MUST be merged into the result, but MUST NOT overwrite fields already set by the normalization logic.
 
-### REQ-006.8: I/O Functions
+### DW-REQ-006.8: I/O Functions
 
 1. `read_stdin()` MUST return an empty string if stdin is a TTY.
 2. `read_stdin()` MUST return an empty string if reading stdin raises any exception.
 3. `write_stdout()` MUST print the data to stdout.
 
-### REQ-006.9: Error Handling
+### DW-REQ-006.9: Error Handling
 
 1. `format_hook_error()` MUST produce a dict with `decision: "block"` and a `reason` containing the error details.
 2. The error reason MUST include: a "Hook Script Error" header, optional context, error type, error message, and full traceback.
 3. `output_hook_error()` MUST serialize the error dict to JSON and print to stdout.
 
-### REQ-006.10: run_hook Entry Point
+### DW-REQ-006.10: run_hook Entry Point
 
 1. `run_hook()` MUST accept a hook function (Callable[[HookInput], HookOutput]) and a Platform.
 2. `run_hook()` MUST read stdin, normalize input, call the hook function, denormalize output, and write to stdout.

--- a/specs/deepwork/DW-REQ-007-git-integration.md
+++ b/specs/deepwork/DW-REQ-007-git-integration.md
@@ -1,4 +1,4 @@
-# REQ-007: Git Integration
+# DW-REQ-007: Git Integration
 
 ## Overview
 
@@ -6,13 +6,13 @@ DeepWork provides Git utility functions for repository operations including bran
 
 ## Requirements
 
-### REQ-007.1: Repository Detection
+### DW-REQ-007.1: Repository Detection
 
 1. `is_git_repo(path)` MUST return `True` if the given path is inside a Git repository.
 2. `is_git_repo(path)` MUST return `False` if the given path is not inside a Git repository.
 3. `is_git_repo()` MUST search parent directories for the Git repository root.
 
-### REQ-007.2: Repository Access
+### DW-REQ-007.2: Repository Access
 
 1. `get_repo(path)` MUST return a GitPython `Repo` object for the given path.
 2. `get_repo(path)` MUST search parent directories for the Git repository root.
@@ -20,7 +20,7 @@ DeepWork provides Git utility functions for repository operations including bran
 4. `get_repo_root(path)` MUST return the `Path` to the repository root (working tree directory).
 5. `get_repo_root(path)` MUST raise `GitError` if the path is not inside a Git repository.
 
-### REQ-007.3: Branch Operations
+### DW-REQ-007.3: Branch Operations
 
 1. `get_current_branch(path)` MUST return the name of the currently checked-out branch.
 2. `get_current_branch(path)` MUST raise `GitError` if HEAD is detached (not on any branch).
@@ -33,14 +33,14 @@ DeepWork provides Git utility functions for repository operations including bran
 9. `create_branch(path, name, checkout=False)` (the default) MUST NOT check out the new branch.
 10. `create_branch()` MUST raise `GitError` if the branch creation fails for any other reason.
 
-### REQ-007.4: Repository Status
+### DW-REQ-007.4: Repository Status
 
 1. `has_uncommitted_changes(path)` MUST return `True` if the repository has staged changes, unstaged changes, or untracked files.
 2. `has_uncommitted_changes(path)` MUST return `False` if the working tree is clean with no untracked files.
 3. `get_untracked_files(path)` MUST return a list of untracked file paths in the repository.
 4. `get_untracked_files(path)` MUST return an empty list if there are no untracked files.
 
-### REQ-007.5: Error Handling
+### DW-REQ-007.5: Error Handling
 
 1. All Git utility functions MUST raise `GitError` (not raw GitPython exceptions) for Git-related failures.
 2. `GitError` MUST include a descriptive message about the failure.

--- a/specs/deepwork/DW-REQ-010-filesystem-utilities.md
+++ b/specs/deepwork/DW-REQ-010-filesystem-utilities.md
@@ -1,4 +1,4 @@
-# REQ-010: Filesystem and YAML Utilities
+# DW-REQ-010: Filesystem and YAML Utilities
 
 ## Overview
 
@@ -6,32 +6,32 @@ DeepWork provides utility modules for safe filesystem operations, YAML loading/s
 
 ## Requirements
 
-### REQ-010.1: File Permission Management
+### DW-REQ-010.1: File Permission Management
 
 1. `fix_permissions()` MUST ensure user read and write permissions on files (minimum `S_IRUSR | S_IWUSR`).
 2. `fix_permissions()` MUST preserve the executable bit on files if already set.
 3. `fix_permissions()` MUST ensure user read, write, and execute permissions on directories (minimum `S_IRWXU`).
 4. `fix_permissions()` MUST recursively fix permissions for all contents of a directory.
 
-### REQ-010.2: Directory Management
+### DW-REQ-010.2: Directory Management
 
 1. `ensure_dir()` MUST create the directory and all parent directories if they do not exist.
 2. `ensure_dir()` MUST NOT raise an error if the directory already exists.
 3. `ensure_dir()` MUST return the Path object for the created or existing directory.
 
-### REQ-010.3: Safe File Writing
+### DW-REQ-010.3: Safe File Writing
 
 1. `safe_write()` MUST create parent directories if they do not exist before writing.
 2. `safe_write()` MUST write content using UTF-8 encoding.
 3. `safe_write()` MUST overwrite existing files.
 
-### REQ-010.4: Safe File Reading
+### DW-REQ-010.4: Safe File Reading
 
 1. `safe_read()` MUST return the file content as a string using UTF-8 encoding.
 2. `safe_read()` MUST return `None` if the file does not exist.
 3. `safe_read()` MUST raise `OSError` if the read fails for reasons other than the file not existing.
 
-### REQ-010.5: Directory Copying
+### DW-REQ-010.5: Directory Copying
 
 1. `copy_dir()` MUST recursively copy the source directory to the destination.
 2. `copy_dir()` MUST use `dirs_exist_ok=True` to allow copying into an existing destination.
@@ -40,14 +40,14 @@ DeepWork provides utility modules for safe filesystem operations, YAML loading/s
 5. `copy_dir()` MUST raise `NotADirectoryError` if the source path is not a directory.
 6. `copy_dir()` MUST support an optional `ignore_patterns` parameter (list of glob patterns) to exclude files/directories from copying.
 
-### REQ-010.6: File Finding
+### DW-REQ-010.6: File Finding
 
 1. `find_files()` MUST return all files matching a glob pattern in the given directory, sorted by path.
 2. `find_files()` MUST return only files, not directories.
 3. `find_files()` MUST raise `FileNotFoundError` if the directory does not exist.
 4. `find_files()` MUST raise `NotADirectoryError` if the path is not a directory.
 
-### REQ-010.7: YAML Loading
+### DW-REQ-010.7: YAML Loading
 
 1. `load_yaml()` MUST parse a YAML file and return a dictionary.
 2. `load_yaml()` MUST return `None` if the file does not exist.
@@ -56,19 +56,19 @@ DeepWork provides utility modules for safe filesystem operations, YAML loading/s
 5. `load_yaml_from_string()` MUST parse a YAML string and return a dictionary.
 6. `load_yaml_from_string()` MUST return `None` for empty content.
 
-### REQ-010.8: YAML Saving
+### DW-REQ-010.8: YAML Saving
 
 1. `save_yaml()` MUST serialize a dictionary to YAML and write to the specified file.
 2. `save_yaml()` MUST create parent directories if they do not exist.
 3. `save_yaml()` MUST use `default_flow_style=False` for readable block-style output.
 4. `save_yaml()` MUST use `sort_keys=False` to preserve insertion order.
 
-### REQ-010.9: YAML Structure Validation
+### DW-REQ-010.9: YAML Structure Validation
 
 1. `validate_yaml_structure()` MUST check that all specified required keys are present in the data dictionary.
 2. Missing required keys MUST be reported in the validation result.
 
-### REQ-010.10: JSON Schema Validation
+### DW-REQ-010.10: JSON Schema Validation
 
 1. `validate_against_schema()` MUST validate a data dictionary against a JSON Schema.
 2. When validation fails, the system MUST raise `ValidationError` with the schema path and validation message extracted from the `jsonschema` library error.

--- a/specs/deepwork/jobs/JOBS-REQ-001-mcp-workflow-tools.md
+++ b/specs/deepwork/jobs/JOBS-REQ-001-mcp-workflow-tools.md
@@ -1,4 +1,4 @@
-# REQ-001: MCP Workflow Tools
+# JOBS-REQ-001: MCP Workflow Tools
 
 ## Overview
 
@@ -6,7 +6,7 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 
 ## Requirements
 
-### REQ-001.1: Server Creation and Configuration
+### JOBS-REQ-001.1: Server Creation and Configuration
 
 1. The system MUST provide a `create_server()` function that returns a configured `FastMCP` instance.
 2. The server MUST accept a `project_root` parameter (Path or str) and resolve it to an absolute path.
@@ -21,7 +21,7 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 11. The server MUST include instructions text describing the workflow lifecycle (Discover, Start, Execute, Checkpoint, Iterate, Continue, Complete).
 12. Every tool call MUST be logged with the tool name and current stack state.
 
-### REQ-001.2: get_workflows Tool
+### JOBS-REQ-001.2: get_workflows Tool
 
 1. The `get_workflows` tool MUST be registered as a synchronous MCP tool.
 2. The tool MUST accept no parameters.
@@ -30,9 +30,9 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 5. Each workflow info object MUST contain `name` and `summary` fields.
 6. The tool MUST also return an `errors` key containing a list of job load error objects for any jobs that failed to parse.
 7. Each job load error object MUST contain `job_name`, `job_dir`, and `error` fields.
-8. The tool MUST load jobs from all configured job folders (see REQ-008).
+8. The tool MUST load jobs from all configured job folders (see JOBS-REQ-008).
 
-### REQ-001.3: start_workflow Tool
+### JOBS-REQ-001.3: start_workflow Tool
 
 1. The `start_workflow` tool MUST be registered as an asynchronous MCP tool.
 2. The tool MUST require the following parameters: `goal` (str), `job_name` (str), `workflow_name` (str).
@@ -49,14 +49,14 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 13. Each expected output in `step_expected_outputs` MUST include `name`, `type`, `description`, `required`, and `syntax_for_finished_step_tool` fields.
 14. The `syntax_for_finished_step_tool` MUST be `"filepath"` for `type: file` outputs and `"array of filepaths for all individual files"` for `type: files` outputs.
 
-### REQ-001.4: finished_step Tool
+### JOBS-REQ-001.4: finished_step Tool
 
 1. The `finished_step` tool MUST be registered as an asynchronous MCP tool.
 2. The tool MUST require an `outputs` parameter: a dict mapping output names to file path(s).
 3. The tool MUST accept optional parameters: `notes` (str), `quality_review_override_reason` (str), `session_id` (str).
 4. The tool MUST raise `StateError` if no active workflow session exists and no `session_id` is provided.
 5. When `session_id` is provided, the tool MUST target the session with that ID rather than the top-of-stack session.
-6. The tool MUST validate submitted outputs against the current step's declared output specifications (see REQ-001.5).
+6. The tool MUST validate submitted outputs against the current step's declared output specifications (see JOBS-REQ-001.5).
 7. The tool MUST return a response with a `status` field that is one of: `"needs_work"`, `"next_step"`, or `"workflow_complete"`.
 
 #### Quality Gate Behavior
@@ -77,7 +77,7 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 18. For concurrent step entries (entries with multiple step IDs), the tool MUST use the first step ID as the primary step and append a message about concurrent execution using the Task tool.
 19. All `finished_step` responses MUST include a `stack` field reflecting the current workflow stack.
 
-### REQ-001.5: Output Validation
+### JOBS-REQ-001.5: Output Validation
 
 1. The system MUST reject submitted output keys that do not match any declared output name. The error MUST list the unknown keys and the valid declared names.
 2. The system MUST reject submissions missing any required output (outputs where `required: true`). The error MUST list the missing required outputs.
@@ -88,7 +88,7 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 7. For outputs declared as `type: "files"`, each element in the list MUST be a string. If not, the system MUST raise `ToolError`.
 8. For outputs declared as `type: "files"`, each file at the specified path (relative to project root) MUST exist. If not, the system MUST raise `ToolError`.
 
-### REQ-001.6: abort_workflow Tool
+### JOBS-REQ-001.6: abort_workflow Tool
 
 1. The `abort_workflow` tool MUST be registered as an asynchronous MCP tool.
 2. The tool MUST require an `explanation` parameter (str).
@@ -99,7 +99,7 @@ The DeepWork MCP server exposes four tools to AI agents via the Model Context Pr
 7. The response MUST contain: `aborted_workflow` (formatted as `"job_name/workflow_name"`), `aborted_step`, `explanation`, `stack`, `resumed_workflow` (or None), and `resumed_step` (or None).
 8. If a parent workflow exists on the stack after abortion, `resumed_workflow` and `resumed_step` MUST reflect that parent's state.
 
-### REQ-001.7: Tool Response Serialization
+### JOBS-REQ-001.7: Tool Response Serialization
 
 1. All tool responses MUST be serialized via Pydantic's `model_dump()` method, returning plain dictionaries.
 2. The `StepStatus` enum values MUST be: `"needs_work"`, `"next_step"`, `"workflow_complete"`.

--- a/specs/deepwork/jobs/JOBS-REQ-002-job-definition-parsing.md
+++ b/specs/deepwork/jobs/JOBS-REQ-002-job-definition-parsing.md
@@ -1,4 +1,4 @@
-# REQ-002: Job Definition Parsing
+# JOBS-REQ-002: Job Definition Parsing
 
 ## Overview
 
@@ -6,7 +6,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 
 ## Requirements
 
-### REQ-002.1: Job File Structure
+### JOBS-REQ-002.1: Job File Structure
 
 1. A valid job directory MUST contain a file named `job.yml`.
 2. The parser MUST raise `ParseError` if the job directory does not exist.
@@ -15,7 +15,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 5. The parser MUST raise `ParseError` if `job.yml` is empty.
 6. The parser MUST raise `ParseError` if `job.yml` contains invalid YAML.
 
-### REQ-002.2: JSON Schema Validation
+### JOBS-REQ-002.2: JSON Schema Validation
 
 1. The job definition MUST be validated against the DeepWork JSON Schema (`job.schema.json`) before dataclass parsing.
 2. The parser MUST raise `ParseError` if schema validation fails, including the validation path and message.
@@ -27,7 +27,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 8. The `steps` array MUST contain at least 1 item.
 9. The top-level object MUST NOT allow additional properties beyond those defined in the schema.
 
-### REQ-002.3: Step Definition
+### JOBS-REQ-002.3: Step Definition
 
 1. Each step MUST have the following required fields: `id`, `name`, `description`, `instructions_file`, `outputs`, `reviews`.
 2. The step `id` MUST match the pattern `^[a-z][a-z0-9_]*$`.
@@ -38,7 +38,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 7. The `exposed` field MUST default to `false`.
 8. Steps MUST NOT allow additional properties beyond those defined in the schema.
 
-### REQ-002.4: Step Inputs
+### JOBS-REQ-002.4: Step Inputs
 
 1. Step inputs MUST be one of two types: user parameter inputs or file inputs.
 2. A user parameter input MUST have `name` and `description` fields (both required, non-empty strings).
@@ -46,14 +46,14 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 4. A `StepInput` MUST correctly report `is_user_input()` as `True` when both `name` and `description` are set.
 5. A `StepInput` MUST correctly report `is_file_input()` as `True` when both `file` and `from_step` are set.
 
-### REQ-002.5: Step Outputs
+### JOBS-REQ-002.5: Step Outputs
 
 1. Each output specification MUST have `type`, `description`, and `required` fields (all required).
 2. The `type` field MUST be one of: `"file"` or `"files"`.
 3. The `description` field MUST be a non-empty string.
 4. The `required` field MUST be a boolean.
 
-### REQ-002.6: Hook Definitions
+### JOBS-REQ-002.6: Hook Definitions
 
 1. The `hooks` object MUST support three lifecycle event keys: `after_agent`, `before_tool`, `before_prompt`.
 2. The `hooks` object MUST NOT allow additional properties beyond these three events.
@@ -63,7 +63,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 6. When both `stop_hooks` and `hooks.after_agent` are present, the `stop_hooks` entries MUST be appended to the existing `after_agent` hooks.
 7. The `HookAction` class MUST provide `is_prompt()`, `is_prompt_file()`, and `is_script()` predicate methods.
 
-### REQ-002.7: Review Definitions
+### JOBS-REQ-002.7: Review Definitions
 
 1. Each review MUST have `run_each` and `quality_criteria` fields (both required).
 2. The `run_each` field MUST be a non-empty string: either `"step"` or the name of a specific output.
@@ -71,7 +71,7 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 4. The `quality_criteria` object MUST contain at least 1 property.
 5. Reviews MAY have an optional `additional_review_guidance` string field.
 
-### REQ-002.8: Workflow Definitions
+### JOBS-REQ-002.8: Workflow Definitions
 
 1. Each workflow MUST have `name`, `summary`, and `steps` fields (all required).
 2. The workflow `name` MUST match the pattern `^[a-z][a-z0-9_]*$`.
@@ -81,33 +81,33 @@ Job definitions are YAML files (`job.yml`) that declare multi-step workflows for
 6. When a step entry is a string, it SHALL be parsed as a `WorkflowStepEntry` with `is_concurrent=False`.
 7. When a step entry is a list, it SHALL be parsed as a `WorkflowStepEntry` with `is_concurrent=True`.
 
-### REQ-002.9: Semantic Validation - Dependencies
+### JOBS-REQ-002.9: Semantic Validation - Dependencies
 
 1. The parser MUST validate that all step dependencies reference existing step IDs. A `ParseError` MUST be raised for any dependency referencing a non-existent step.
 2. The parser MUST detect circular dependencies using topological sort and raise `ParseError` if a cycle is found.
 
-### REQ-002.10: Semantic Validation - File Inputs
+### JOBS-REQ-002.10: Semantic Validation - File Inputs
 
 1. For every file input, the `from_step` MUST reference an existing step. A `ParseError` MUST be raised otherwise.
 2. For every file input, the `from_step` MUST be listed in the consuming step's `dependencies` array. A `ParseError` MUST be raised otherwise.
 
-### REQ-002.11: Semantic Validation - Reviews
+### JOBS-REQ-002.11: Semantic Validation - Reviews
 
 1. For every review, if `run_each` is not `"step"`, it MUST match the name of a declared output on that step. A `ParseError` MUST be raised otherwise, listing the valid values.
 
-### REQ-002.12: Semantic Validation - Workflows
+### JOBS-REQ-002.12: Semantic Validation - Workflows
 
 1. The parser MUST reject duplicate workflow names within the same job.
 2. The parser MUST reject workflow step references to non-existent step IDs.
 3. The parser MUST reject duplicate step IDs within a single workflow.
 
-### REQ-002.13: Orphaned Step Detection
+### JOBS-REQ-002.13: Orphaned Step Detection
 
 1. After validation, the parser MUST identify steps not included in any workflow.
 2. Orphaned steps MUST be logged as warnings.
 3. Orphaned step detection MUST return the list of orphaned step IDs.
 
-### REQ-002.14: JobDefinition Navigation Methods
+### JOBS-REQ-002.14: JobDefinition Navigation Methods
 
 1. `get_step(step_id)` MUST return the Step if found, or `None` otherwise.
 2. `get_workflow_for_step(step_id)` MUST return the Workflow containing the step, or `None` if standalone.

--- a/specs/deepwork/jobs/JOBS-REQ-003-workflow-session-management.md
+++ b/specs/deepwork/jobs/JOBS-REQ-003-workflow-session-management.md
@@ -1,4 +1,4 @@
-# REQ-003: Workflow Session Management
+# JOBS-REQ-003: Workflow Session Management
 
 ## Overview
 
@@ -6,20 +6,20 @@ The StateManager manages workflow session state with support for stack-based nes
 
 ## Requirements
 
-### REQ-003.1: StateManager Initialization
+### JOBS-REQ-003.1: StateManager Initialization
 
 1. The StateManager MUST accept a `project_root` Path parameter.
 2. The StateManager MUST store session files in `{project_root}/.deepwork/tmp/`.
 3. The StateManager MUST maintain an in-memory session stack (`_session_stack`) as a list.
 4. The StateManager MUST hold an `asyncio.Lock` for concurrent access safety.
 
-### REQ-003.2: Session ID Generation
+### JOBS-REQ-003.2: Session ID Generation
 
 1. Session IDs MUST be generated from UUID4 values.
 2. Session IDs MUST be exactly 8 characters long (the first 8 characters of the UUID4 string representation).
 3. Each generated session ID MUST be unique within the server's lifetime.
 
-### REQ-003.3: Session Creation
+### JOBS-REQ-003.3: Session Creation
 
 1. `create_session()` MUST be an async method.
 2. `create_session()` MUST acquire the async lock before modifying state.
@@ -32,7 +32,7 @@ The StateManager manages workflow session state with support for stack-based nes
 9. `create_session()` MUST append the session to the in-memory stack.
 10. The returned `WorkflowSession` MUST contain all provided parameters (job_name, workflow_name, goal, instance_id, first_step_id).
 
-### REQ-003.4: Session Persistence
+### JOBS-REQ-003.4: Session Persistence
 
 1. Session state MUST be persisted to `{sessions_dir}/session_{session_id}.json`.
 2. Session files MUST be JSON-formatted with 2-space indentation.
@@ -40,7 +40,7 @@ The StateManager manages workflow session state with support for stack-based nes
 4. The `_save_session_unlocked()` method MUST be called only when the lock is already held.
 5. The `_save_session()` method MUST acquire the lock before saving.
 
-### REQ-003.5: Session Loading
+### JOBS-REQ-003.5: Session Loading
 
 1. `load_session()` MUST be an async method.
 2. `load_session()` MUST raise `StateError` if the session file does not exist.
@@ -48,20 +48,20 @@ The StateManager manages workflow session state with support for stack-based nes
 4. When the in-memory stack is non-empty, `load_session()` MUST replace the top-of-stack with the loaded session.
 5. When the in-memory stack is empty, `load_session()` MUST push the loaded session onto the stack.
 
-### REQ-003.6: Active Session Access
+### JOBS-REQ-003.6: Active Session Access
 
 1. `get_active_session()` MUST return the top-of-stack session, or `None` if the stack is empty.
 2. `require_active_session()` MUST return the top-of-stack session.
 3. `require_active_session()` MUST raise `StateError` with an instructive message if the stack is empty.
 
-### REQ-003.7: Session ID Routing
+### JOBS-REQ-003.7: Session ID Routing
 
 1. `_resolve_session(session_id)` MUST search the entire stack for a session matching the provided `session_id`.
 2. If `session_id` is provided but not found in the stack, `_resolve_session()` MUST raise `StateError`.
 3. If `session_id` is `None`, `_resolve_session()` MUST fall back to `require_active_session()` (top-of-stack).
 4. All state-modifying methods that accept `session_id` (start_step, complete_step, record_quality_attempt, advance_to_step, complete_workflow, abort_workflow) MUST use `_resolve_session()` for session lookup.
 
-### REQ-003.8: Step Progress Tracking
+### JOBS-REQ-003.8: Step Progress Tracking
 
 1. `start_step()` MUST create a `StepProgress` entry if one does not exist for the step.
 2. `start_step()` MUST update `started_at` to the current UTC ISO timestamp.
@@ -72,20 +72,20 @@ The StateManager manages workflow session state with support for stack-based nes
 7. `complete_step()` MUST record the outputs and notes on the step progress.
 8. `complete_step()` MUST persist the session after modification.
 
-### REQ-003.9: Quality Attempt Tracking
+### JOBS-REQ-003.9: Quality Attempt Tracking
 
 1. `record_quality_attempt()` MUST increment the `quality_attempts` counter on the step's progress.
 2. `record_quality_attempt()` MUST create a `StepProgress` entry if one does not exist.
 3. `record_quality_attempt()` MUST return the updated total attempt count.
 4. `record_quality_attempt()` MUST persist the session after modification.
 
-### REQ-003.10: Step Advancement
+### JOBS-REQ-003.10: Step Advancement
 
 1. `advance_to_step()` MUST update `current_step_id` to the new step ID.
 2. `advance_to_step()` MUST update `current_entry_index` to the new entry index.
 3. `advance_to_step()` MUST persist the session after modification.
 
-### REQ-003.11: Workflow Completion
+### JOBS-REQ-003.11: Workflow Completion
 
 1. `complete_workflow()` MUST set `completed_at` to the current UTC ISO timestamp.
 2. `complete_workflow()` MUST set `status` to `"completed"`.
@@ -93,7 +93,7 @@ The StateManager manages workflow session state with support for stack-based nes
 4. `complete_workflow()` MUST remove the completed session from the in-memory stack using filter (not pop), to support mid-stack removal.
 5. `complete_workflow()` MUST return the new top-of-stack session, or `None` if the stack is empty.
 
-### REQ-003.12: Workflow Abortion
+### JOBS-REQ-003.12: Workflow Abortion
 
 1. `abort_workflow()` MUST set `completed_at` to the current UTC ISO timestamp.
 2. `abort_workflow()` MUST set `status` to `"aborted"`.
@@ -102,7 +102,7 @@ The StateManager manages workflow session state with support for stack-based nes
 5. `abort_workflow()` MUST remove the aborted session from the in-memory stack using filter (not pop), to support mid-stack removal.
 6. `abort_workflow()` MUST return a tuple of (aborted session, new active session or None).
 
-### REQ-003.13: Workflow Stack (Nesting)
+### JOBS-REQ-003.13: Workflow Stack (Nesting)
 
 1. Starting a new workflow while one is active MUST push the new session onto the stack (nesting).
 2. The stack MUST maintain ordering from bottom (oldest) to top (newest/active).
@@ -110,32 +110,32 @@ The StateManager manages workflow session state with support for stack-based nes
 4. `get_stack_depth()` MUST return the number of sessions on the stack.
 5. Completing or aborting a workflow MUST remove only that specific session from the stack, not necessarily the top.
 
-### REQ-003.14: Output Aggregation
+### JOBS-REQ-003.14: Output Aggregation
 
 1. `get_all_outputs()` MUST merge outputs from all completed steps in the targeted session.
 2. Later steps' outputs MUST overwrite earlier steps' outputs when keys conflict.
 3. `get_all_outputs()` MUST accept an optional `session_id` parameter for targeting specific sessions.
 
-### REQ-003.15: Session Listing and Querying
+### JOBS-REQ-003.15: Session Listing and Querying
 
 1. `list_sessions()` MUST scan all `session_*.json` files in the sessions directory.
 2. `list_sessions()` MUST skip corrupted files (invalid JSON, validation errors) without raising.
 3. `list_sessions()` MUST return sessions sorted by `started_at` in descending order (most recent first).
 4. `find_active_sessions_for_workflow()` MUST filter sessions by job_name, workflow_name, and `status == "active"`.
 
-### REQ-003.16: Session Deletion
+### JOBS-REQ-003.16: Session Deletion
 
 1. `delete_session()` MUST remove the session file from disk if it exists.
 2. `delete_session()` MUST remove the session from the in-memory stack if present.
 3. `delete_session()` MUST acquire the lock before modifying state.
 
-### REQ-003.17: Async Safety
+### JOBS-REQ-003.17: Async Safety
 
 1. All state-modifying operations MUST acquire the `asyncio.Lock` before making changes.
 2. The StateManager MUST be safe for concurrent async access within a single event loop.
 3. The lock MUST be an `asyncio.Lock` instance (not threading.Lock).
 
-### REQ-003.18: WorkflowSession Data Model
+### JOBS-REQ-003.18: WorkflowSession Data Model
 
 1. The `WorkflowSession` model MUST support serialization via `to_dict()` using Pydantic `model_dump()`.
 2. The `WorkflowSession` model MUST support deserialization via `from_dict()` using Pydantic `model_validate()`.

--- a/specs/deepwork/jobs/JOBS-REQ-004-quality-review-system.md
+++ b/specs/deepwork/jobs/JOBS-REQ-004-quality-review-system.md
@@ -1,4 +1,4 @@
-# REQ-004: Quality Review System
+# JOBS-REQ-004: Quality Review System
 
 ## Overview
 
@@ -6,7 +6,7 @@ The quality review system evaluates step outputs against defined quality criteri
 
 ## Requirements
 
-### REQ-004.1: QualityGate Initialization
+### JOBS-REQ-004.1: QualityGate Initialization
 
 1. The `QualityGate` MUST accept an optional `cli` parameter (`ClaudeCLI` or `None`).
 2. The `QualityGate` MUST accept an optional `max_inline_files` parameter (integer).
@@ -15,7 +15,7 @@ The quality review system evaluates step outputs against defined quality criteri
 5. A `QualityGate` with `cli=None` MUST still support `build_review_instructions_file()` for self-review mode.
 6. A `QualityGate` with `cli=None` MUST raise `QualityGateError` if `evaluate()` is called directly.
 
-### REQ-004.2: Review Modes
+### JOBS-REQ-004.2: Review Modes
 
 #### External Runner Mode (CLI Subprocess)
 
@@ -34,7 +34,7 @@ The quality review system evaluates step outputs against defined quality criteri
 10. The `finished_step` response in self-review mode MUST return `status: "needs_work"` with instructions for spawning a subagent.
 11. The subagent instructions MUST direct the agent to: (a) read the review file, (b) evaluate criteria, (c) fix issues, (d) repeat until passing, (e) call `finished_step` again with `quality_review_override_reason`.
 
-### REQ-004.3: Payload Construction
+### JOBS-REQ-004.3: Payload Construction
 
 1. When the total number of output files is less than or equal to `max_inline_files`, the payload MUST include full file contents inline.
 2. When the total number of output files exceeds `max_inline_files`, the payload MUST switch to path-listing mode showing only file paths.
@@ -45,7 +45,7 @@ The quality review system evaluates step outputs against defined quality criteri
 7. If author notes are provided, they MUST be included in a separate AUTHOR NOTES section.
 8. If no files are provided and no notes exist, the payload MUST return `"[No files provided]"`.
 
-### REQ-004.4: File Reading
+### JOBS-REQ-004.4: File Reading
 
 1. The system MUST read files in an async-friendly way (such as `aiofiles`)
 2. For files that exist and are valid UTF-8, the system MUST include the full text content. [TODO: review this]
@@ -53,7 +53,7 @@ The quality review system evaluates step outputs against defined quality criteri
 4. For files that do not exist, the system MUST include a `"[File not found]"` placeholder.
 5. For files that encounter other read errors, the system MUST include an `"[Error reading file: {error}]"` placeholder.
 
-### REQ-004.5: Review Instruction Building (Self-Review)
+### JOBS-REQ-004.5: Review Instruction Building (Self-Review)
 
 1. The `build_review_instructions_file()` method MUST produce a complete markdown document.
 2. When there are multiple reviews, each review section MUST be numbered and include its scope (e.g., "all outputs together" or "output 'name'").
@@ -63,14 +63,14 @@ The quality review system evaluates step outputs against defined quality criteri
 6. The guidelines section MUST instruct the reviewer to be strict but fair, apply criteria pragmatically, and provide actionable feedback.
 7. The task section MUST list 5 steps: read files, evaluate criteria, report PASS/FAIL, state overall result, provide feedback for failures.
 
-### REQ-004.6: Review Evaluation (External Runner)
+### JOBS-REQ-004.6: Review Evaluation (External Runner)
 
 1. When `quality_criteria` is empty, `evaluate()` MUST return an auto-pass result with `passed=True` and feedback `"No quality criteria defined - auto-passing"`.
 2. When `_cli` is `None`, `evaluate()` MUST raise `QualityGateError`.
-3. The system MUST use a dynamic timeout based on file count (see REQ-004.8).
+3. The system MUST use a dynamic timeout based on file count (see JOBS-REQ-004.8).
 4. ClaudeCLI errors MUST be caught and re-raised as `QualityGateError`.
 
-### REQ-004.7: Multi-Review Evaluation
+### JOBS-REQ-004.7: Multi-Review Evaluation
 
 1. `evaluate_reviews()` MUST process all reviews for a step.
 2. When the `reviews` list is empty, `evaluate_reviews()` MUST return an empty list (no failures).
@@ -81,13 +81,13 @@ The quality review system evaluates step outputs against defined quality criteri
 7. `evaluate_reviews()` MUST return only the failed reviews (where `passed=False`).
 8. The `additional_review_guidance` from each review MUST be passed through to the underlying `evaluate()` call.
 
-### REQ-004.8: Timeout Computation
+### JOBS-REQ-004.8: Timeout Computation
 
 1. The base timeout MUST be 240 seconds (4 minutes).
 2. For file counts of 5 or fewer, the timeout MUST be 240 seconds.
 3. For file counts beyond 5, the timeout MUST increase by 30 seconds per additional file.
 
-### REQ-004.9: Result Parsing
+### JOBS-REQ-004.9: Result Parsing
 
 1. The `_parse_result()` method MUST extract `passed`, `feedback`, and `criteria_results` from the structured output.
 2. If `passed` is missing, it MUST default to `False`.
@@ -95,7 +95,7 @@ The quality review system evaluates step outputs against defined quality criteri
 4. If `criteria_results` is missing, it MUST default to an empty list.
 5. If the data cannot be interpreted, a `QualityGateError` MUST be raised.
 
-### REQ-004.10: Review Instructions Sections
+### JOBS-REQ-004.10: Review Instructions Sections
 
 1. The instructions MUST include a system prompt instructing the reviewer role.
 2. The criteria list MUST be formatted as markdown bold name/question pairs.

--- a/specs/deepwork/jobs/JOBS-REQ-008-job-discovery.md
+++ b/specs/deepwork/jobs/JOBS-REQ-008-job-discovery.md
@@ -1,4 +1,4 @@
-# REQ-008: Job Discovery and Standard Jobs
+# JOBS-REQ-008: Job Discovery and Standard Jobs
 
 ## Overview
 
@@ -6,7 +6,7 @@ DeepWork discovers job definitions from multiple folder sources with a defined p
 
 ## Requirements
 
-### REQ-008.1: Job Folder Discovery
+### JOBS-REQ-008.1: Job Folder Discovery
 
 1. The system MUST provide a `get_job_folders()` function that returns an ordered list of directories to scan for job definitions.
 2. The first folder in the list MUST be `{project_root}/.deepwork/jobs/` (project-local jobs).
@@ -18,7 +18,7 @@ DeepWork discovers job definitions from multiple folder sources with a defined p
 8. Whitespace around entries MUST be stripped.
 9. The returned list MAY include non-existent paths; callers MUST handle non-existent paths gracefully.
 
-### REQ-008.2: Job Loading
+### JOBS-REQ-008.2: Job Loading
 
 1. `load_all_jobs()` MUST scan each folder from `get_job_folders()` in order.
 2. Non-existent or non-directory folders MUST be silently skipped.
@@ -32,22 +32,22 @@ DeepWork discovers job definitions from multiple folder sources with a defined p
 10. Failed jobs MUST be logged as warnings.
 11. `load_all_jobs()` MUST return a tuple of `(list[JobDefinition], list[JobLoadError])`.
 
-### REQ-008.3: Job Directory Lookup
+### JOBS-REQ-008.3: Job Directory Lookup
 
 1. `find_job_dir()` MUST search all folders from `get_job_folders()` in priority order.
 2. `find_job_dir()` MUST return the first directory matching the job name that is a directory and contains a `job.yml` file.
 3. `find_job_dir()` MUST return `None` if no matching job directory is found in any folder.
 4. Non-existent or non-directory folders in the search path MUST be silently skipped.
 
-### REQ-008.4: Standard Jobs
+### JOBS-REQ-008.4: Standard Jobs
 
 1. Standard jobs MUST be located in `src/deepwork/standard_jobs/` within the package.
 2. Standard jobs MUST be automatically discoverable without any user configuration.
 3. The `deepwork_jobs` standard job MUST be bundled with the package.
-4. Standard jobs MUST follow the same `job.yml` format and validation rules as any other job (see REQ-002).
+4. Standard jobs MUST follow the same `job.yml` format and validation rules as any other job (see JOBS-REQ-002).
 5. Project-local jobs (in `.deepwork/jobs/`) MUST take precedence over standard jobs with the same directory name.
 
-### REQ-008.5: Job Load Error Reporting
+### JOBS-REQ-008.5: Job Load Error Reporting
 
 1. The `JobLoadError` dataclass MUST contain: `job_name` (str), `job_dir` (str), `error` (str).
 2. Load errors MUST be surfaced to callers (e.g., `get_workflows` tool) so agents can see which jobs failed and why.

--- a/specs/deepwork/jobs/JOBS-REQ-009-claude-cli-subprocess.md
+++ b/specs/deepwork/jobs/JOBS-REQ-009-claude-cli-subprocess.md
@@ -1,4 +1,4 @@
-# REQ-009: Claude CLI Subprocess Wrapper
+# JOBS-REQ-009: Claude CLI Subprocess Wrapper
 
 ## Overview
 
@@ -6,14 +6,14 @@ The `ClaudeCLI` class wraps the Claude Code CLI as an async subprocess for use i
 
 ## Requirements
 
-### REQ-009.1: Initialization
+### JOBS-REQ-009.1: Initialization
 
 1. The `ClaudeCLI` MUST accept a `timeout` parameter in seconds (default: 120).
 2. The `ClaudeCLI` MUST accept an optional `_test_command` parameter (list of strings) for testing purposes.
 3. When `_test_command` is set, it MUST be used as the base command instead of the `claude` binary.
 4. When `_test_command` is set, the `--json-schema` flag MUST NOT be added to the command (the test mock handles it).
 
-### REQ-009.2: Command Construction
+### JOBS-REQ-009.2: Command Construction
 
 1. The command MUST invoke the `claude` binary.
 2. The command MUST include the `--print` flag for non-interactive mode.
@@ -24,7 +24,7 @@ The `ClaudeCLI` class wraps the Claude Code CLI as an async subprocess for use i
 7. All flags MUST appear BEFORE `-p --` in the command. This ordering is required because `-p` expects a prompt argument and `--` marks the end of flags.
 8. When `_test_command` is provided, the command MUST be `[_test_command..., "--system-prompt", system_prompt]`.
 
-### REQ-009.3: Subprocess Execution
+### JOBS-REQ-009.3: Subprocess Execution
 
 1. `run()` MUST be an async method.
 2. `run()` MUST create the subprocess using `asyncio.create_subprocess_exec`.
@@ -34,7 +34,7 @@ The `ClaudeCLI` class wraps the Claude Code CLI as an async subprocess for use i
 6. The `run()` method MUST accept an optional `timeout` parameter that overrides the instance default for that call.
 7. When no per-call timeout is provided, the instance-level timeout MUST be used.
 
-### REQ-009.4: Response Parsing
+### JOBS-REQ-009.4: Response Parsing
 
 1. The `_parse_wrapper()` method MUST parse the stdout output as JSON.
 2. If the JSON response contains `is_error: true`, the method MUST raise `ClaudeCLIError` with the error result.
@@ -42,7 +42,7 @@ The `ClaudeCLI` class wraps the Claude Code CLI as an async subprocess for use i
 4. If `structured_output` is missing (None), the method MUST raise `ClaudeCLIError` with a truncated excerpt of the response (first 500 characters).
 5. If the stdout is not valid JSON, the method MUST raise `ClaudeCLIError` with parse error details and a truncated excerpt.
 
-### REQ-009.5: Error Handling
+### JOBS-REQ-009.5: Error Handling
 
 1. If the subprocess times out, the system MUST kill the process and raise `ClaudeCLIError` indicating the timeout duration.
 2. If the subprocess exits with a non-zero return code, the system MUST raise `ClaudeCLIError` with the exit code and stderr content.

--- a/specs/deepwork/review/REVIEW-REQ-001-deepreview-config.md
+++ b/specs/deepwork/review/REVIEW-REQ-001-deepreview-config.md
@@ -1,4 +1,4 @@
-# REQ-001: DeepWork Reviews Configuration Format
+# REVIEW-REQ-001: DeepWork Reviews Configuration Format
 
 ## Overview
 
@@ -6,7 +6,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 
 ## Requirements
 
-### REQ-001.1: Configuration File Format
+### REVIEW-REQ-001.1: Configuration File Format
 
 1. A `.deepreview` file MUST be a valid YAML document.
 2. The top-level structure MUST be a mapping of rule names to rule objects.
@@ -14,7 +14,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 4. Each rule object MUST contain exactly three required keys: `description`, `match`, and `review`.
 5. Rule objects MUST NOT contain additional properties beyond `description`, `match`, and `review`.
 
-### REQ-001.2: Match Section
+### REVIEW-REQ-001.2: Match Section
 
 1. The `match` section MUST be an object.
 2. The `match` section MUST contain an `include` key with a non-empty array of glob pattern strings.
@@ -22,7 +22,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 4. The `match` section MUST NOT contain additional properties beyond `include` and `exclude`.
 5. Glob patterns MUST support standard glob syntax including `**` for recursive directory matching and `*` for filename matching.
 
-### REQ-001.3: Review Section
+### REVIEW-REQ-001.3: Review Section
 
 1. The `review` section MUST be an object.
 2. The `review` section MUST contain a `strategy` key with one of: `"individual"`, `"matches_together"`, or `"all_changed_files"`.
@@ -31,7 +31,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 5. The `review` section MAY contain an `additional_context` key.
 6. The `review` section MUST NOT contain additional properties beyond `strategy`, `instructions`, `agent`, and `additional_context`.
 
-### REQ-001.4: Instructions
+### REVIEW-REQ-001.4: Instructions
 
 1. The `instructions` field MUST be one of two forms: an inline string, or an object with a `file` key.
 2. When `instructions` is a string, the string MUST be used directly as the review instruction text.
@@ -40,7 +40,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 5. The system MUST raise an error if a referenced instructions file does not exist.
 6. The instructions object MUST NOT contain additional properties beyond `file`.
 
-### REQ-001.5: Agent Configuration
+### REVIEW-REQ-001.5: Agent Configuration
 
 1. The `agent` field, when present, MUST be an object mapping CLI provider names to agent persona strings.
 2. Provider names MUST match the pattern `^[a-zA-Z0-9_-]+$`.
@@ -48,7 +48,7 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 4. The system MUST select the agent persona matching the target platform (e.g., the `claude` key when generating instructions for Claude Code).
 5. When no matching agent key exists for the target platform, the system MUST use the default agent (no persona).
 
-### REQ-001.6: Additional Context
+### REVIEW-REQ-001.6: Additional Context
 
 1. The `additional_context` field, when present, MUST be an object.
 2. The `additional_context` object MAY contain `all_changed_filenames` (boolean).
@@ -57,15 +57,15 @@ DeepWork Reviews uses `.deepreview` YAML configuration files to define review ru
 5. When `all_changed_filenames` is `true`, the system MUST include a list of all files changed in the changeset (not just matched files) as context in the review instructions.
 6. When `unchanged_matching_files` is `true`, the system MUST include the full contents of files that match the `include` patterns but were NOT modified in this changeset.
 
-### REQ-001.7: Schema Validation
+### REVIEW-REQ-001.7: Schema Validation
 
 1. The JSON Schema for `.deepreview` files MUST be bundled with the DeepWork package at `src/deepwork/schemas/deepreview_schema.json`.
 2. The schema MUST be loaded at module import time and stored as a module-level constant.
 3. Every `.deepreview` file MUST be validated against the schema before parsing into data models.
 4. The system MUST raise an error with a descriptive message if schema validation fails, including the validation path and error details.
-5. Schema validation MUST use the `jsonschema` library (same as job definition validation, see REQ-002.2).
+5. Schema validation MUST use the `jsonschema` library (same as job definition validation, see REVIEW-REQ-002.2).
 
-### REQ-001.8: Data Model
+### REVIEW-REQ-001.8: Data Model
 
 1. Each parsed rule MUST be represented as a `ReviewRule` dataclass.
 2. The `ReviewRule` MUST contain: `name` (str), `description` (str), `include_patterns` (list[str]), `exclude_patterns` (list[str]), `strategy` (str), `instructions` (str — resolved text), `agent` (dict[str, str] | None), `all_changed_filenames` (bool), `unchanged_matching_files` (bool), `source_dir` (Path), `source_file` (Path), `source_line` (int).

--- a/specs/deepwork/review/REVIEW-REQ-002-config-discovery.md
+++ b/specs/deepwork/review/REVIEW-REQ-002-config-discovery.md
@@ -1,4 +1,4 @@
-# REQ-002: Configuration Discovery
+# REVIEW-REQ-002: Configuration Discovery
 
 ## Overview
 
@@ -6,7 +6,7 @@ DeepWork Reviews configuration files (`.deepreview`) can be placed anywhere with
 
 ## Requirements
 
-### REQ-002.1: File Discovery
+### REVIEW-REQ-002.1: File Discovery
 
 1. The system MUST provide a `find_deepreview_files(project_root)` function that returns a list of `.deepreview` file paths.
 2. The function MUST search `project_root` and all its subdirectories recursively.
@@ -15,22 +15,22 @@ DeepWork Reviews configuration files (`.deepreview`) can be placed anywhere with
 5. The function MUST return paths sorted by depth (deepest files first), then alphabetically within the same depth.
 6. If no `.deepreview` files are found, the function MUST return an empty list.
 
-### REQ-002.2: Scope Boundaries
+### REVIEW-REQ-002.2: Scope Boundaries
 
 1. The discovery MUST be bounded to the `project_root` directory and its descendants.
 2. The discovery MUST NOT traverse above `project_root`.
 3. The `project_root` SHOULD be the git repository root, but the system MUST NOT require it to be a git repository for discovery purposes.
 
-### REQ-002.3: Rule Loading
+### REVIEW-REQ-002.3: Rule Loading
 
 1. The system MUST provide a `load_all_rules(project_root)` function that discovers all `.deepreview` files and parses each into `ReviewRule` objects.
-2. Each `.deepreview` file MUST be parsed and validated according to REQ-001.
+2. Each `.deepreview` file MUST be parsed and validated according to REVIEW-REQ-001.
 3. The `source_dir` of each `ReviewRule` MUST be set to the parent directory of the `.deepreview` file it was parsed from.
 4. If a `.deepreview` file fails to parse (invalid YAML, schema validation failure, or missing instructions file), the error MUST be reported but MUST NOT prevent other `.deepreview` files from being processed.
 5. `load_all_rules()` MUST return both the successfully parsed rules and a list of errors (file path + error message).
 6. Rules from different `.deepreview` files MUST be independent — a rule from `src/.deepreview` does not interact with or override a rule from the root `.deepreview`.
 
-### REQ-002.4: Symlinks and Special Files
+### REVIEW-REQ-002.4: Symlinks and Special Files
 
 1. The discovery MUST follow the default behavior of the underlying directory traversal (do not follow symlinks by default).
 2. The system MUST skip unreadable directories or files and continue discovery.

--- a/specs/deepwork/review/REVIEW-REQ-003-changed-file-detection.md
+++ b/specs/deepwork/review/REVIEW-REQ-003-changed-file-detection.md
@@ -1,4 +1,4 @@
-# REQ-003: Changed File Detection
+# REVIEW-REQ-003: Changed File Detection
 
 ## Overview
 
@@ -6,7 +6,7 @@ DeepWork Reviews needs to determine which files have changed in order to match t
 
 ## Requirements
 
-### REQ-003.1: Changed File Retrieval
+### REVIEW-REQ-003.1: Changed File Retrieval
 
 1. The system MUST provide a `get_changed_files(project_root, base_ref)` function that returns a list of changed file paths relative to the repository root.
 2. The function MUST use `subprocess.run()` to invoke `git diff --name-only` with appropriate flags.
@@ -18,7 +18,7 @@ DeepWork Reviews needs to determine which files have changed in order to match t
 8. The returned list MUST be sorted alphabetically.
 9. The function MUST raise an error if the `git` command fails (e.g., not a git repository, invalid base ref).
 
-### REQ-003.2: Base Reference
+### REVIEW-REQ-003.2: Base Reference
 
 1. The `base_ref` parameter MUST default to `None`.
 2. When `base_ref` is `None`, the system MUST auto-detect the merge base by finding the common ancestor between HEAD and the main branch.
@@ -27,12 +27,12 @@ DeepWork Reviews needs to determine which files have changed in order to match t
 5. When `base_ref` is provided explicitly (e.g., `"main"`, `"HEAD"`, a commit SHA), the system MUST use it directly as the comparison target.
 6. The system MUST use `git merge-base` to find the common ancestor when comparing against a branch name, to avoid including changes from the target branch itself.
 
-### REQ-003.3: Working Directory
+### REVIEW-REQ-003.3: Working Directory
 
 1. All git commands MUST be executed with `cwd` set to `project_root`.
 2. The function MUST NOT change the process working directory.
 
-### REQ-003.4: Error Handling
+### REVIEW-REQ-003.4: Error Handling
 
 1. If the project is not a git repository, the function MUST raise an error with a descriptive message.
 2. If the specified `base_ref` does not exist, the function MUST raise an error with a descriptive message.

--- a/specs/deepwork/review/REVIEW-REQ-004-rule-matching-and-strategies.md
+++ b/specs/deepwork/review/REVIEW-REQ-004-rule-matching-and-strategies.md
@@ -1,12 +1,12 @@
-# REQ-004: Rule Matching and Review Strategies
+# REVIEW-REQ-004: Rule Matching and Review Strategies
 
 ## Overview
 
-After discovering review rules (REQ-002) and changed files (REQ-003), the system matches changed files against each rule's glob patterns, then groups the matched files according to the rule's review strategy. The result is a list of `ReviewTask` objects, each representing a discrete review to be performed by an agent. Glob patterns are always resolved relative to the directory containing the `.deepreview` file that defined the rule.
+After discovering review rules (REVIEW-REQ-002) and changed files (REVIEW-REQ-003), the system matches changed files against each rule's glob patterns, then groups the matched files according to the rule's review strategy. The result is a list of `ReviewTask` objects, each representing a discrete review to be performed by an agent. Glob patterns are always resolved relative to the directory containing the `.deepreview` file that defined the rule.
 
 ## Requirements
 
-### REQ-004.1: Glob Pattern Matching
+### REVIEW-REQ-004.1: Glob Pattern Matching
 
 1. Include patterns MUST be matched against file paths that are relative to the rule's `source_dir`.
 2. A changed file MUST first be checked to determine whether it resides under the rule's `source_dir`. If the changed file is not under `source_dir`, it MUST NOT match any patterns in that rule.
@@ -16,21 +16,21 @@ After discovering review rules (REQ-002) and changed files (REQ-003), the system
 6. A file MUST match a rule if it matches ANY of the `include` patterns AND does NOT match ANY of the `exclude` patterns.
 7. If `exclude` is empty, only `include` patterns determine the match.
 
-### REQ-004.2: Review Task Data Model
+### REVIEW-REQ-004.2: Review Task Data Model
 
 1. Each review task MUST be represented as a `ReviewTask` dataclass.
 2. The `ReviewTask` MUST contain: `rule_name` (str), `files_to_review` (list[str] — paths relative to repo root), `instructions` (str), `agent_name` (str | None), `source_location` (str — formatted as `"path:line"`), `additional_files` (list[str] — unchanged matching files, relative to repo root), `all_changed_filenames` (list[str] | None).
 3. `files_to_review` MUST always contain at least one file path.
 4. `source_location` MUST be formatted as `"{relative_path}:{line_number}"` where the path is relative to the project root (e.g., `"src/.deepreview:5"`).
 
-### REQ-004.3: Strategy — individual
+### REVIEW-REQ-004.3: Strategy — individual
 
 1. When a rule's strategy is `"individual"`, the system MUST create one `ReviewTask` per matched changed file.
 2. Each task's `files_to_review` MUST contain exactly one file path.
 3. The task's `rule_name` MUST be the rule name.
 4. The task's `instructions` MUST be the rule's resolved instruction text.
 
-### REQ-004.4: Strategy — matches_together
+### REVIEW-REQ-004.4: Strategy — matches_together
 
 1. When a rule's strategy is `"matches_together"`, the system MUST create a single `ReviewTask` containing all matched changed files.
 2. The task's `files_to_review` MUST contain all matched changed files.
@@ -38,29 +38,29 @@ After discovering review rules (REQ-002) and changed files (REQ-003), the system
 4. These unchanged matching files MUST be included in the task's `additional_files` list.
 5. To discover unchanged matching files, the system MUST scan the filesystem using the rule's glob patterns relative to `source_dir`.
 
-### REQ-004.5: Strategy — all_changed_files
+### REVIEW-REQ-004.5: Strategy — all_changed_files
 
 1. When a rule's strategy is `"all_changed_files"`, the system MUST create a single `ReviewTask` only if at least one changed file matches the rule's patterns.
 2. If triggered, the task's `files_to_review` MUST contain ALL changed files from the changeset (not just the matched ones).
 3. This strategy acts as a "tripwire": the match patterns determine IF the review triggers, but the review itself covers the entire changeset.
 
-### REQ-004.6: Additional Context — all_changed_filenames
+### REVIEW-REQ-004.6: Additional Context — all_changed_filenames
 
 1. When a rule has `all_changed_filenames: true`, every `ReviewTask` generated from that rule MUST include the full list of all changed filenames in `all_changed_filenames`.
 2. This list MUST include ALL changed files in the changeset, regardless of whether they matched the rule's patterns.
 
-### REQ-004.7: No-Match Behavior
+### REVIEW-REQ-004.7: No-Match Behavior
 
 1. If no changed files match a rule's patterns, the system MUST NOT create any `ReviewTask` for that rule.
 2. If no rules produce any tasks, the overall result MUST be an empty list.
 
-### REQ-004.8: Agent Resolution
+### REVIEW-REQ-004.8: Agent Resolution
 
 1. When generating a `ReviewTask`, the system MUST accept a `platform` parameter (e.g., `"claude"`).
 2. If the rule defines an `agent` mapping and the mapping contains a key matching the platform, the corresponding value MUST be set as the task's `agent_name`.
 3. If the rule defines no `agent` mapping, or the mapping does not contain the target platform key, `agent_name` MUST be `None`.
 
-### REQ-004.9: Orchestration
+### REVIEW-REQ-004.9: Orchestration
 
 1. The system MUST provide a `match_files_to_rules(changed_files, rules, project_root, platform="claude")` function that processes all rules and returns a list of `ReviewTask` objects.
 2. Each rule MUST be processed independently — a file can match multiple rules and appear in multiple tasks.

--- a/specs/deepwork/review/REVIEW-REQ-005-instruction-generation.md
+++ b/specs/deepwork/review/REVIEW-REQ-005-instruction-generation.md
@@ -1,4 +1,4 @@
-# REQ-005: Review Instruction Generation
+# REVIEW-REQ-005: Review Instruction Generation
 
 ## Overview
 
@@ -6,7 +6,7 @@ For each `ReviewTask`, the system generates a self-contained markdown instructio
 
 ## Requirements
 
-### REQ-005.1: Instruction File Content
+### REVIEW-REQ-005.1: Instruction File Content
 
 1. Each instruction file MUST be a valid markdown document.
 2. The file MUST begin with a heading identifying the review rule and scope (e.g., `# Review: python_file_best_practices — src/app.py`).
@@ -16,13 +16,13 @@ For each `ReviewTask`, the system generates a self-contained markdown instructio
 6. When the task has `additional_files` (unchanged matching files), the file MUST contain an "Unchanged Matching Files" section listing those file paths.
 7. When the task has `all_changed_filenames`, the file MUST contain an "All Changed Files" section listing every changed filename for context.
 
-### REQ-005.2: File Path Formatting
+### REVIEW-REQ-005.2: File Path Formatting
 
 1. File paths in the "Files to Review" section MUST be prefixed with `@` to trigger Claude Code's file-reading behavior (e.g., `@src/app.py`).
 2. File paths in the "Unchanged Matching Files" section MUST also be prefixed with `@`.
 3. File paths in the "All Changed Files" section MUST NOT be prefixed with `@` (they are listed for informational context only, not for the agent to read in full).
 
-### REQ-005.3: File Writing
+### REVIEW-REQ-005.3: File Writing
 
 1. Instruction files MUST be written to `.deepwork/tmp/review_instructions/` under the project root.
 2. The directory MUST be created if it does not exist (with `parents=True, exist_ok=True`).
@@ -31,17 +31,17 @@ For each `ReviewTask`, the system generates a self-contained markdown instructio
 5. The system MUST use `fs.safe_write()` for writing instruction files.
 6. The system MUST return a list of `(ReviewTask, Path)` tuples mapping each task to its generated instruction file path.
 
-### REQ-005.4: Instruction Resolution
+### REVIEW-REQ-005.4: Instruction Resolution
 
 1. When the rule's instructions reference a file (`{file: "path"}`), the system MUST resolve the path relative to the rule's `source_dir` and read the file contents.
 2. The resolved instruction text MUST be included verbatim in the instruction file.
 3. If the referenced file cannot be read, the system MUST raise an error with the file path and reason.
 
-### REQ-005.5: Cleanup
+### REVIEW-REQ-005.5: Cleanup
 
 1. The system SHOULD clear the `.deepwork/tmp/review_instructions/` directory at the start of each `deepwork review` invocation to avoid stale instruction files from previous runs.
 
-### REQ-005.6: Policy Traceability
+### REVIEW-REQ-005.6: Policy Traceability
 
 1. Each instruction file MUST end with a traceability line linking back to the source `.deepreview` file and rule location.
 2. The traceability line MUST be formatted as: `This review was requested by the policy at \`{source_location}\`.` where `source_location` is the relative file path and line number (e.g., `src/.deepreview:5`).

--- a/specs/deepwork/review/REVIEW-REQ-006-cli-review-command.md
+++ b/specs/deepwork/review/REVIEW-REQ-006-cli-review-command.md
@@ -1,4 +1,4 @@
-# REQ-006: CLI Review Command
+# REVIEW-REQ-006: CLI Review Command
 
 ## Overview
 
@@ -6,7 +6,7 @@ The `deepwork review` CLI command orchestrates the full DeepWork Reviews pipelin
 
 ## Requirements
 
-### REQ-006.1: Command Definition
+### REVIEW-REQ-006.1: Command Definition
 
 1. The `review` command MUST be a Click command registered in the DeepWork CLI.
 2. The command MUST be registered in `src/deepwork/cli/main.py` via `cli.add_command(review)`.
@@ -15,17 +15,17 @@ The `deepwork review` CLI command orchestrates the full DeepWork Reviews pipelin
 5. The command MUST accept a `--path` option (default: `"."`, must exist, must be a directory) specifying the project root.
 6. The command MUST accept a `--files` option that can be specified multiple times to provide explicit file paths to review.
 
-### REQ-006.2: Pipeline Orchestration
+### REVIEW-REQ-006.2: Pipeline Orchestration
 
 1. The command MUST execute the following pipeline in order:
-   a. Discover all `.deepreview` files under the project root (REQ-002).
-   b. Determine changed files (see REQ-006.6).
-   c. Match changed files against discovered rules and group by strategy (REQ-004).
-   d. Generate review instruction files for each task (REQ-005).
+   a. Discover all `.deepreview` files under the project root (REVIEW-REQ-002).
+   b. Determine changed files (see REVIEW-REQ-006.6).
+   c. Match changed files against discovered rules and group by strategy (REVIEW-REQ-004).
+   d. Generate review instruction files for each task (REVIEW-REQ-005).
    e. Format and output the results for the target platform.
 2. If any step in the pipeline fails with an error, the command MUST print a user-friendly error message to stderr and exit with code 1.
 
-### REQ-006.3: Output Format for Claude Code
+### REVIEW-REQ-006.3: Output Format for Claude Code
 
 1. When `--instructions-for claude` is specified, the command MUST output to stdout a structured text block that Claude Code can use to dispatch parallel review agents.
 2. The output MUST begin with a line instructing the agent to invoke tasks in parallel.
@@ -36,25 +36,25 @@ The `deepwork review` CLI command orchestrates the full DeepWork Reviews pipelin
    d. A `prompt` field referencing the instruction file path relative to the project root, prefixed with `@` (e.g., `@.deepwork/tmp/review_instructions/7142141.md`).
 4. The instruction file paths MUST be relative to the project root.
 
-### REQ-006.4: Empty Results
+### REVIEW-REQ-006.4: Empty Results
 
 1. If no `.deepreview` files are found, the command MUST output a message indicating no review configuration was found.
 2. If no changed files are detected, the command MUST output a message indicating no changes were found to review.
 3. If changed files exist but no rules match, the command MUST output a message indicating no review rules matched the changed files.
 
-### REQ-006.5: Error Handling
+### REVIEW-REQ-006.5: Error Handling
 
-1. Configuration parse errors MUST be reported to stderr but MUST NOT prevent other `.deepreview` files from being processed (see REQ-002.3).
+1. Configuration parse errors MUST be reported to stderr but MUST NOT prevent other `.deepreview` files from being processed (see REVIEW-REQ-002.3).
 2. Git errors MUST be reported to stderr and the command MUST exit with code 1.
 3. Instruction file write errors MUST be reported to stderr and the command MUST exit with code 1.
 
-### REQ-006.6: Changed File Sources
+### REVIEW-REQ-006.6: Changed File Sources
 
 The command supports three sources for the list of files to review, with the following priority:
 
 1. **`--files` arguments** (highest priority): When one or more `--files` options are provided, the command MUST use those file paths directly and MUST NOT invoke git diff or read stdin.
 2. **stdin** (second priority): When no `--files` are provided and stdin is not a TTY (i.e., input is piped), the command MUST read file paths from stdin (one per line, blank lines ignored). This allows chaining with other commands (e.g., `git diff --name-only HEAD~3 | deepwork review ...` or `find src -name '*.py' | deepwork review ...`).
-3. **git diff** (default): When neither `--files` nor piped stdin is present, the command MUST fall back to detecting changed files via git diff (REQ-003).
+3. **git diff** (default): When neither `--files` nor piped stdin is present, the command MUST fall back to detecting changed files via git diff (REVIEW-REQ-003).
 
 In all cases:
 4. The resulting file list MUST be sorted and deduplicated.

--- a/specs/deepwork/review/REVIEW-REQ-007-plugin-skills.md
+++ b/specs/deepwork/review/REVIEW-REQ-007-plugin-skills.md
@@ -1,4 +1,4 @@
-# REQ-007: Plugin Skills and Documentation
+# REVIEW-REQ-007: Plugin Skills and Documentation
 
 ## Overview
 
@@ -6,7 +6,7 @@ DeepWork Reviews is delivered to users via the Claude Code plugin. The plugin sh
 
 ## Requirements
 
-### REQ-007.1: Review Skill
+### REVIEW-REQ-007.1: Review Skill
 
 1. The plugin MUST include a `review` skill at `plugins/claude/skills/review/SKILL.md`.
 2. The skill's YAML frontmatter MUST contain a `name` field set to `"review"`.
@@ -18,7 +18,7 @@ DeepWork Reviews is delivered to users via the Claude Code plugin. The plugin sh
 8. The skill MUST instruct the agent to re-run the review after making changes, repeating until no further actionable findings remain.
 9. The skill MUST route configuration requests (creating or modifying `.deepreview` files) to the `configure_reviews` skill.
 
-### REQ-007.2: Configure Reviews Skill
+### REVIEW-REQ-007.2: Configure Reviews Skill
 
 1. The plugin MUST include a `configure_reviews` skill at `plugins/claude/skills/configure_reviews/SKILL.md`.
 2. The skill's YAML frontmatter MUST contain a `name` field set to `"configure_reviews"`.
@@ -27,7 +27,7 @@ DeepWork Reviews is delivered to users via the Claude Code plugin. The plugin sh
 5. The skill MUST instruct the agent to look at existing `.deepreview` files and reuse rules/instructions where possible.
 6. The skill MUST instruct the agent to test changes by running `deepwork review --instructions-for claude` and verifying the new rule appears in the output.
 
-### REQ-007.3: Reference Documentation
+### REVIEW-REQ-007.3: Reference Documentation
 
 1. The plugin MUST include `README_REVIEWS.md` at `plugins/claude/README_REVIEWS.md`.
 2. This file MUST be a symlink to `../../README_REVIEWS.md` (the project root copy).
@@ -35,7 +35,7 @@ DeepWork Reviews is delivered to users via the Claude Code plugin. The plugin sh
 4. The `README_REVIEWS.md` MUST document the `.deepreview` configuration format, all review strategies, instruction variants (inline and file reference), agent personas, and CLI usage.
 5. The documentation MUST recommend `.deepwork/review/` as the location for reusable instruction files.
 
-### REQ-007.4: Skill Directory Conventions
+### REVIEW-REQ-007.4: Skill Directory Conventions
 
 1. Each skill MUST be in its own directory under `plugins/claude/skills/`.
 2. Each skill directory MUST contain a `SKILL.md` file.

--- a/specs/deepwork/review/REVIEW-REQ-008-get-configured-reviews.md
+++ b/specs/deepwork/review/REVIEW-REQ-008-get-configured-reviews.md
@@ -1,4 +1,4 @@
-# REQ-008: Get Configured Reviews MCP Tool
+# REVIEW-REQ-008: Get Configured Reviews MCP Tool
 
 ## Overview
 
@@ -6,24 +6,24 @@ The `get_configured_reviews` MCP tool allows agents to query which review rules 
 
 ## Requirements
 
-### REQ-008.1: Tool Registration
+### REVIEW-REQ-008.1: Tool Registration
 
 1. The tool MUST be registered as `get_configured_reviews` on the MCP server.
 2. The tool MUST accept an optional `only_rules_matching_files` parameter (list of file paths).
-3. The tool MUST return a list of rule summaries (see REQ-008.2).
+3. The tool MUST return a list of rule summaries (see REVIEW-REQ-008.2).
 
-### REQ-008.2: Rule Summary
+### REVIEW-REQ-008.2: Rule Summary
 
 1. Each entry in the returned list MUST include `name` (str) — the rule name from the `.deepreview` file.
 2. Each entry MUST include `description` (str) — the rule's description field.
 3. Each entry MUST include `defining_file` (str) — a relative path to the `.deepreview` file with line number (e.g., `.deepreview:1`).
 
-### REQ-008.3: File Filtering
+### REVIEW-REQ-008.3: File Filtering
 
 1. When `only_rules_matching_files` is provided, the tool MUST return only rules whose include/exclude patterns match at least one of the provided files.
 2. When `only_rules_matching_files` is omitted (None), the tool MUST return all configured rules.
 
-### REQ-008.4: Error Handling
+### REVIEW-REQ-008.4: Error Handling
 
 1. The tool MUST handle discovery errors gracefully — if some `.deepreview` files are invalid, valid rules from other files MUST still be returned.
 2. Discovery errors MUST NOT cause the tool to raise an exception.

--- a/specs/learning-agents/LA-REQ-001-plugin-structure.md
+++ b/specs/learning-agents/LA-REQ-001-plugin-structure.md
@@ -1,4 +1,4 @@
-# REQ-001: Plugin Structure and Metadata
+# LA-REQ-001: Plugin Structure and Metadata
 
 ## Overview
 
@@ -6,7 +6,7 @@ The learning-agents plugin is a Claude Code plugin distributed via the DeepWork 
 
 ## Requirements
 
-### REQ-001.1: Plugin Manifest
+### LA-REQ-001.1: Plugin Manifest
 
 The plugin MUST provide a `.claude-plugin/plugin.json` file at the plugin root containing:
 - `name` set to `"learning-agents"`
@@ -15,14 +15,14 @@ The plugin MUST provide a `.claude-plugin/plugin.json` file at the plugin root c
 - `author.name` as a non-empty string
 - `repository` as a valid URL string
 
-### REQ-001.2: Marketplace Registration
+### LA-REQ-001.2: Marketplace Registration
 
 The plugin MUST be registered in the repository's `.claude-plugin/marketplace.json` under the `plugins` array with:
 - `name` matching the plugin manifest name (`"learning-agents"`)
 - `source` pointing to the plugin root directory relative to the repository root
 - `category` set to `"learning"`
 
-### REQ-001.3: Plugin Root Directory Layout
+### LA-REQ-001.3: Plugin Root Directory Layout
 
 The plugin root directory MUST contain the following subdirectories:
 - `.claude-plugin/` -- plugin manifest
@@ -32,24 +32,24 @@ The plugin root directory MUST contain the following subdirectories:
 - `scripts/` -- executable utility scripts
 - `skills/` -- skill definitions
 
-### REQ-001.4: Hooks Configuration
+### LA-REQ-001.4: Hooks Configuration
 
 The plugin MUST provide a `hooks/hooks.json` file that declares:
 - A `PostToolUse` hook with matcher `"Task"` that executes `post_task.sh`
 - A `Stop` hook with empty matcher (`""`) that executes `session_stop.sh`
 
-### REQ-001.5: Hook Script References
+### LA-REQ-001.5: Hook Script References
 
 Hook commands in `hooks.json` MUST reference scripts using `${CLAUDE_PLUGIN_ROOT}` as the base path prefix so they resolve correctly regardless of installation location.
 
-### REQ-001.6: Hook Scripts Exit Code
+### LA-REQ-001.6: Hook Scripts Exit Code
 
 All hook scripts (`post_task.sh`, `session_stop.sh`) MUST always exit with code 0 to ensure they are non-blocking. A hook script MUST NOT cause the host CLI session to fail.
 
-### REQ-001.7: Hook Scripts Output Format
+### LA-REQ-001.7: Hook Scripts Output Format
 
 All hook scripts MUST write valid JSON to stdout. When there is nothing to communicate, the script MUST output `{}`. When there is a message, the script MUST output a JSON object with a `systemMessage` string field.
 
-### REQ-001.8: Meta-Agent Definition
+### LA-REQ-001.8: Meta-Agent Definition
 
 The plugin MUST provide an `agents/learning-agent-expert.md` file that defines a meta-agent with expertise in the LearningAgent system. This agent definition MUST include dynamic context injection commands (using `!` backtick syntax) that load all reference documentation from `${CLAUDE_PLUGIN_ROOT}/doc/`.

--- a/specs/learning-agents/LA-REQ-002-agent-creation.md
+++ b/specs/learning-agents/LA-REQ-002-agent-creation.md
@@ -1,4 +1,4 @@
-# REQ-002: Agent Creation
+# LA-REQ-002: Agent Creation
 
 ## Overview
 
@@ -6,39 +6,39 @@ The `create-agent` skill scaffolds a new LearningAgent by creating the required 
 
 ## Requirements
 
-### REQ-002.1: Skill Invocation
+### LA-REQ-002.1: Skill Invocation
 
 The `create-agent` skill MUST be invocable via `/learning-agents create <name>`. If no name argument is provided, the skill MUST prompt the user for a name.
 
-### REQ-002.2: Name Normalization
+### LA-REQ-002.2: Name Normalization
 
 The skill MUST normalize agent names by converting spaces and uppercase letters to lowercase dashes (e.g., `"Rails ActiveJob"` becomes `"rails-activejob"`).
 
-### REQ-002.3: Conflict Detection -- Claude Agent File
+### LA-REQ-002.3: Conflict Detection -- Claude Agent File
 
 Before creation, the skill MUST check `.claude/agents/` for an existing file matching `<agent-name>.md`. If a conflict is found, the skill MUST inform the user and ask how to proceed before taking any action.
 
-### REQ-002.4: Conflict Detection -- Agent Directory
+### LA-REQ-002.4: Conflict Detection -- Agent Directory
 
 If the agent directory `.deepwork/learning-agents/<agent-name>/` already exists, the skill MUST inform the user and ask whether to proceed with updating the configuration or stop.
 
-### REQ-002.5: Scaffold Script Execution
+### LA-REQ-002.5: Scaffold Script Execution
 
 The skill MUST execute the scaffold script at `${CLAUDE_PLUGIN_ROOT}/scripts/create_agent.sh` passing the normalized agent name as the first argument and, when a template path is provided, the template path as the second argument.
 
-### REQ-002.6: Scaffold Script -- Agent Directory Creation
+### LA-REQ-002.6: Scaffold Script -- Agent Directory Creation
 
 The `create_agent.sh` script MUST create the following directory structure when the agent directory does not exist:
-- `.deepwork/learning-agents/<agent-name>/core-knowledge.md` -- with TODO placeholder content (when no template is provided; see REQ-002.19 for template behavior)
+- `.deepwork/learning-agents/<agent-name>/core-knowledge.md` -- with TODO placeholder content (when no template is provided; see LA-REQ-002.19 for template behavior)
 - `.deepwork/learning-agents/<agent-name>/topics/` -- with `.gitkeep`
 - `.deepwork/learning-agents/<agent-name>/learnings/` -- with `.gitkeep`
 - `.deepwork/learning-agents/<agent-name>/additional_learning_guidelines/` -- containing `README.md`, `issue_identification.md`, `issue_investigation.md`, and `learning_from_issues.md`
 
-### REQ-002.7: Scaffold Script -- Additional Learning Guidelines README
+### LA-REQ-002.7: Scaffold Script -- Additional Learning Guidelines README
 
 The `create_agent.sh` script MUST create an `additional_learning_guidelines/README.md` file that describes the purpose of each guideline file (`issue_identification.md`, `issue_investigation.md`, `learning_from_issues.md`).
 
-### REQ-002.8: Scaffold Script -- Claude Agent File Creation
+### LA-REQ-002.8: Scaffold Script -- Claude Agent File Creation
 
 The `create_agent.sh` script MUST create `.claude/agents/<agent-name>.md` with:
 - YAML frontmatter containing `name` and `description` fields (initially set to `"TODO"`)
@@ -46,68 +46,68 @@ The `create_agent.sh` script MUST create `.claude/agents/<agent-name>.md` with:
 - A Topics section with dynamic listing of topic files
 - A Learnings section referencing the learnings directory
 
-### REQ-002.9: Scaffold Script -- Agent Name Substitution
+### LA-REQ-002.9: Scaffold Script -- Agent Name Substitution
 
 The `create_agent.sh` script MUST replace the `__AGENT__` placeholder in the generated Claude agent file with the actual agent name using `sed`.
 
-### REQ-002.10: Scaffold Script -- Idempotency
+### LA-REQ-002.10: Scaffold Script -- Idempotency
 
 The `create_agent.sh` script MUST NOT overwrite existing directories or files. If the agent directory already exists, it MUST print a message to stderr and skip directory creation. If the Claude agent file already exists, it MUST print a message to stderr and skip file creation.
 
-### REQ-002.11: Scaffold Script -- Input Validation
+### LA-REQ-002.11: Scaffold Script -- Input Validation
 
 The `create_agent.sh` script MUST require a non-empty agent name argument. If no argument is provided, it MUST print a usage message to stderr and exit with code 1.
 
-### REQ-002.12: Interactive Configuration
+### LA-REQ-002.12: Interactive Configuration
 
 After scaffolding, the skill MUST ask the user about the agent's domain of expertise and the kinds of tasks it will handle, then update:
 - `core-knowledge.md` -- replacing the TODO content with domain expertise written in second person
 - `.claude/agents/<agent-name>.md` frontmatter -- replacing TODO `name` with a human-readable display name and TODO `description` with a concise invocation description (2-3 sentences max)
 
-### REQ-002.13: Optional Knowledge Seeding
+### LA-REQ-002.13: Optional Knowledge Seeding
 
-The skill MUST offer the user the option to seed initial topics or learnings. If the user accepts, the skill MUST create files following the topic and learning file formats defined in REQ-003.
+The skill MUST offer the user the option to seed initial topics or learnings. If the user accepts, the skill MUST create files following the topic and learning file formats defined in LA-REQ-003.
 
-### REQ-002.14: Creation Summary
+### LA-REQ-002.14: Creation Summary
 
 Upon completion, the skill MUST output a summary listing all files created or modified, usage instructions for invoking the agent via the Task tool, and a note about the learning cycle.
 
-### REQ-002.15: No Overwrites Without Confirmation
+### LA-REQ-002.15: No Overwrites Without Confirmation
 
 The skill MUST NOT overwrite any existing file without explicit user confirmation.
 
-### REQ-002.16: Scaffold Script -- Template Agent Argument
+### LA-REQ-002.16: Scaffold Script -- Template Agent Argument
 
 The `create_agent.sh` script MUST accept an optional second positional argument `[template-agent-path]` specifying the path to an existing LearningAgent directory. When not provided, the script MUST behave identically to the non-template flow (creating TODO placeholder content in `core-knowledge.md`).
 
-### REQ-002.17: Scaffold Script -- Template Validation -- Directory Existence
+### LA-REQ-002.17: Scaffold Script -- Template Validation -- Directory Existence
 
 When a template path argument is provided, the script MUST verify that the path is an existing directory. If the directory does not exist, the script MUST print an error message containing the path to stderr and exit with code 1.
 
-### REQ-002.18: Scaffold Script -- Template Validation -- Core Knowledge Required
+### LA-REQ-002.18: Scaffold Script -- Template Validation -- Core Knowledge Required
 
 When a template path argument is provided and the directory exists, the script MUST verify that the template directory contains a `core-knowledge.md` file. If the file is missing, the script MUST print an error message containing the path to stderr and exit with code 1.
 
-### REQ-002.19: Scaffold Script -- Template Seeding -- Core Knowledge
+### LA-REQ-002.19: Scaffold Script -- Template Seeding -- Core Knowledge
 
 When a valid template path is provided, the script MUST copy `core-knowledge.md` from the template directory into the new agent's directory instead of creating the TODO placeholder content.
 
-### REQ-002.20: Scaffold Script -- Template Seeding -- Topics
+### LA-REQ-002.20: Scaffold Script -- Template Seeding -- Topics
 
 When a valid template path is provided, the script MUST copy all `.md` files from the template's `topics/` directory into the new agent's `topics/` directory. If no `.md` files exist in the template's `topics/` directory, the new agent's `topics/` directory MUST remain empty (aside from `.gitkeep`).
 
-### REQ-002.21: Scaffold Script -- Template Seeding -- Learnings
+### LA-REQ-002.21: Scaffold Script -- Template Seeding -- Learnings
 
 When a valid template path is provided, the script MUST copy all `.md` files from the template's `learnings/` directory into the new agent's `learnings/` directory. If no `.md` files exist in the template's `learnings/` directory, the new agent's `learnings/` directory MUST remain empty (aside from `.gitkeep`).
 
-### REQ-002.22: Scaffold Script -- Template Copy Reporting
+### LA-REQ-002.22: Scaffold Script -- Template Copy Reporting
 
 When files are copied from a template, the script MUST output a confirmation message for the core-knowledge copy. The script MUST output the count of copied topic files when at least one topic was copied. The script MUST output the count of copied learning files when at least one learning was copied.
 
-### REQ-002.23: Skill -- Template Configuration Guidance
+### LA-REQ-002.23: Skill -- Template Configuration Guidance
 
 When a template was used, the skill MUST read the copied `core-knowledge.md` and present it to the user, asking whether to keep it as-is, modify it for the new agent's focus, or replace it entirely. The skill MUST also list any copied topics and learnings and offer the user the opportunity to review, remove, or add to them.
 
-### REQ-002.24: Skill -- Template Argument Parsing
+### LA-REQ-002.24: Skill -- Template Argument Parsing
 
 The skill MUST parse `$ARGUMENTS` to extract the agent name (first token) and an optional template path (second token). Both tokens MUST be passed to the scaffold script as separate positional arguments.

--- a/specs/learning-agents/LA-REQ-003-agent-file-structure.md
+++ b/specs/learning-agents/LA-REQ-003-agent-file-structure.md
@@ -1,4 +1,4 @@
-# REQ-003: Agent File Structure and Knowledge Base
+# LA-REQ-003: Agent File Structure and Knowledge Base
 
 ## Overview
 
@@ -6,23 +6,23 @@ Each LearningAgent has a well-defined file structure under `.deepwork/learning-a
 
 ## Requirements
 
-### REQ-003.1: Agent Root Directory
+### LA-REQ-003.1: Agent Root Directory
 
 Each LearningAgent MUST reside in `.deepwork/learning-agents/<agent-name>/` where `<agent-name>` uses dashes for word separation (e.g., `rails-activejob`, `data-pipeline`).
 
-### REQ-003.2: Folder Name as Source of Truth
+### LA-REQ-003.2: Folder Name as Source of Truth
 
 The folder name under `.deepwork/learning-agents/` MUST be the authoritative source of truth for the agent's name. All references to the agent (in session tracking, Claude agent files, skills) MUST use this folder name.
 
-### REQ-003.3: Core Knowledge File -- Required
+### LA-REQ-003.3: Core Knowledge File -- Required
 
 Each agent MUST have a `core-knowledge.md` file at the agent root directory. This file is REQUIRED for the agent to function.
 
-### REQ-003.4: Core Knowledge File -- Format
+### LA-REQ-003.4: Core Knowledge File -- Format
 
 The `core-knowledge.md` file MUST be plain markdown with no YAML frontmatter. It MUST be written in second person ("You should...", "You are an expert on...") because it is injected as the agent's system instructions.
 
-### REQ-003.5: Core Knowledge File -- Content Structure
+### LA-REQ-003.5: Core Knowledge File -- Content Structure
 
 The `core-knowledge.md` file SHOULD be structured as:
 1. Identity statement ("You are an expert on...")
@@ -31,11 +31,11 @@ The `core-knowledge.md` file SHOULD be structured as:
 4. Pitfalls to avoid
 5. Decision frameworks
 
-### REQ-003.6: Topics Directory
+### LA-REQ-003.6: Topics Directory
 
 Each agent MUST have a `topics/` subdirectory for conceptual reference material about areas within the agent's domain.
 
-### REQ-003.7: Topic File Format
+### LA-REQ-003.7: Topic File Format
 
 Each topic file in `topics/` MUST be a markdown file with YAML frontmatter containing:
 - `name` (REQUIRED): Human-readable topic name
@@ -44,15 +44,15 @@ Each topic file in `topics/` MUST be a markdown file with YAML frontmatter conta
 
 The body MUST contain detailed documentation about the topic area.
 
-### REQ-003.8: Topic File Naming
+### LA-REQ-003.8: Topic File Naming
 
 Topic filenames MUST use dashes and be descriptively named (e.g., `retry-handling.md`). The `.md` extension is REQUIRED.
 
-### REQ-003.9: Learnings Directory
+### LA-REQ-003.9: Learnings Directory
 
 Each agent MUST have a `learnings/` subdirectory for experience-based incident post-mortems.
 
-### REQ-003.10: Learning File Format
+### LA-REQ-003.10: Learning File Format
 
 Each learning file in `learnings/` MUST be a markdown file with YAML frontmatter containing:
 - `name` (REQUIRED): Descriptive name of the learning
@@ -61,15 +61,15 @@ Each learning file in `learnings/` MUST be a markdown file with YAML frontmatter
 
 The body SHOULD contain sections: Context, Investigation, Resolution, and Key Takeaway.
 
-### REQ-003.11: Learning File Naming
+### LA-REQ-003.11: Learning File Naming
 
 Learning filenames MUST use dashes and be descriptively named. The `.md` extension is REQUIRED.
 
-### REQ-003.12: Topics vs Learnings Distinction
+### LA-REQ-003.12: Topics vs Learnings Distinction
 
 Topics MUST document conceptual reference material (how things work -- patterns, APIs, conventions, decision frameworks). Learnings MUST document incident post-mortems of specific mistakes (what went wrong and why -- debugging narratives where the context matters for understanding the lesson).
 
-### REQ-003.13: Additional Learning Guidelines Directory
+### LA-REQ-003.13: Additional Learning Guidelines Directory
 
 Each agent MUST have an `additional_learning_guidelines/` subdirectory containing:
 - `README.md` -- explaining each file's purpose
@@ -77,11 +77,11 @@ Each agent MUST have an `additional_learning_guidelines/` subdirectory containin
 - `issue_investigation.md` -- extra guidance for the investigate step
 - `learning_from_issues.md` -- extra guidance for the incorporate step
 
-### REQ-003.14: Additional Learning Guidelines -- Dynamic Inclusion
+### LA-REQ-003.14: Additional Learning Guidelines -- Dynamic Inclusion
 
 Each additional learning guideline file MUST be dynamically included (via `!` backtick syntax) in the corresponding learning cycle skill's Context section. Empty files MUST result in no additional guidance (default behavior).
 
-### REQ-003.15: Claude Code Agent File
+### LA-REQ-003.15: Claude Code Agent File
 
 Each LearningAgent MUST have a corresponding `.claude/agents/<agent-name>.md` file with:
 - YAML frontmatter containing `name` (human-readable display name) and `description` (concise invocation description, 2-3 sentences max)
@@ -89,14 +89,14 @@ Each LearningAgent MUST have a corresponding `.claude/agents/<agent-name>.md` fi
 - A Topics section with dynamic listing of available topic files
 - A Learnings section referencing the learnings directory
 
-### REQ-003.16: Agent Name Consistency
+### LA-REQ-003.16: Agent Name Consistency
 
 The Claude Code agent filename (`.claude/agents/<agent-name>.md`) MUST match the LearningAgent folder name under `.deepwork/learning-agents/`.
 
-### REQ-003.17: Discovery Description Location
+### LA-REQ-003.17: Discovery Description Location
 
 The agent's discovery description (used by Claude Code to decide whether to invoke this agent) MUST reside in the `.claude/agents/<agent-name>.md` frontmatter `description` field, NOT in the `core-knowledge.md` file.
 
-### REQ-003.18: Knowledge Injection at Invocation Time
+### LA-REQ-003.18: Knowledge Injection at Invocation Time
 
 Both topics and learnings MUST be injected into the agent's prompt at invocation time via the Claude Code agent file. Topics and learnings MUST NOT be baked into the `core-knowledge.md` file.

--- a/specs/learning-agents/LA-REQ-004-session-tracking.md
+++ b/specs/learning-agents/LA-REQ-004-session-tracking.md
@@ -1,4 +1,4 @@
-# REQ-004: Session Tracking and Hooks
+# LA-REQ-004: Session Tracking and Hooks
 
 ## Overview
 
@@ -6,78 +6,78 @@ The learning-agents plugin uses hooks to automatically track when LearningAgents
 
 ## Requirements
 
-### REQ-004.1: PostToolUse Hook Trigger
+### LA-REQ-004.1: PostToolUse Hook Trigger
 
 The PostToolUse hook MUST fire after every use of the `Task` tool. The hook matcher in `hooks.json` MUST be set to `"Task"`.
 
-### REQ-004.2: Post-Task Input Parsing
+### LA-REQ-004.2: Post-Task Input Parsing
 
 The `post_task.sh` hook MUST read JSON from stdin containing `session_id`, `tool_input`, and `tool_response` fields. If stdin is empty or not provided (terminal is interactive), the hook MUST output `{}` and exit 0.
 
-### REQ-004.3: Session ID Extraction
+### LA-REQ-004.3: Session ID Extraction
 
 The hook MUST extract `session_id` from the hook input JSON via `.session_id`. If `session_id` is missing or empty, the hook MUST output `{}` and exit 0.
 
-### REQ-004.4: Agent Name Extraction
+### LA-REQ-004.4: Agent Name Extraction
 
 The hook MUST extract the agent name from `.tool_input.name` in the hook input JSON. If the agent name is missing or empty, the hook MUST output `{}` and exit 0.
 
-### REQ-004.5: Agent ID Extraction
+### LA-REQ-004.5: Agent ID Extraction
 
 The hook MUST extract the agent ID from `.tool_response.agentId` (falling back to `.tool_response.agent_id`) in the hook input JSON. If the agent ID is missing or empty, the hook MUST output `{}` and exit 0.
 
-### REQ-004.6: LearningAgent Detection
+### LA-REQ-004.6: LearningAgent Detection
 
 The hook MUST check whether `.deepwork/learning-agents/<agent-name>/` exists. If the directory does NOT exist, the Task was not for a LearningAgent and the hook MUST output `{}` and exit 0 without creating any files.
 
-### REQ-004.7: Session Directory Creation
+### LA-REQ-004.7: Session Directory Creation
 
 When a LearningAgent is detected, the hook MUST create the directory `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/` (including all parent directories).
 
-### REQ-004.8: Needs Learning Timestamp File
+### LA-REQ-004.8: Needs Learning Timestamp File
 
 The hook MUST create a `needs_learning_as_of_timestamp` file in the session directory containing a single ISO 8601 UTC timestamp (format: `YYYY-MM-DDTHH:MM:SSZ`). This file serves as a flag indicating that the session transcript has not yet been processed for learnings.
 
-### REQ-004.9: Agent Used File
+### LA-REQ-004.9: Agent Used File
 
 The hook MUST create an `agent_used` file in the session directory containing the agent name (matching the folder name under `.deepwork/learning-agents/`). This links the session's agent ID back to the LearningAgent definition.
 
-### REQ-004.10: Post-Task Reminder Message
+### LA-REQ-004.10: Post-Task Reminder Message
 
 After creating session tracking files, the hook MUST output a JSON `systemMessage` containing the content of `${CLAUDE_PLUGIN_ROOT}/doc/learning_agent_post_task_reminder.md`. If the reminder file does not exist, the hook MUST output `{}`.
 
-### REQ-004.11: Post-Task Reminder Content
+### LA-REQ-004.11: Post-Task Reminder Content
 
 The post-task reminder MUST instruct the user to:
 - Resume the same task rather than starting a new one if they need more from the same agent
 - Report issues via `/learning-agents report_issue` or by resuming the conversation if the agent made a mistake
 
-### REQ-004.12: Stop Hook Trigger
+### LA-REQ-004.12: Stop Hook Trigger
 
 The Stop hook MUST fire at session end. The hook matcher in `hooks.json` MUST be set to an empty string (`""`) so it triggers for all stop events.
 
-### REQ-004.13: Stop Hook -- No Sessions Directory
+### LA-REQ-004.13: Stop Hook -- No Sessions Directory
 
 If `.deepwork/tmp/agent_sessions` does not exist, the stop hook MUST output `{}` and exit 0.
 
-### REQ-004.14: Stop Hook -- Pending Session Detection
+### LA-REQ-004.14: Stop Hook -- Pending Session Detection
 
 The stop hook MUST search for all `needs_learning_as_of_timestamp` files under `.deepwork/tmp/agent_sessions/`. If none are found, it MUST output `{}` and exit 0.
 
-### REQ-004.15: Stop Hook -- Agent Name Resolution
+### LA-REQ-004.15: Stop Hook -- Agent Name Resolution
 
 For each pending session found, the stop hook MUST read the corresponding `agent_used` file to determine which agent was used. It MUST deduplicate agent names before including them in the suggestion message.
 
-### REQ-004.16: Stop Hook -- Learning Suggestion Message
+### LA-REQ-004.16: Stop Hook -- Learning Suggestion Message
 
 When pending sessions exist, the stop hook MUST output a JSON `systemMessage` that:
 - Lists the unique agent names that were used
 - Suggests running `/learning-agents learn` to process the transcripts
 
-### REQ-004.17: Session Directory Location
+### LA-REQ-004.17: Session Directory Location
 
 All session tracking files MUST be stored under `.deepwork/tmp/agent_sessions/`. The `.deepwork/tmp/` directory is intended for transient working files and MAY be gitignored.
 
-### REQ-004.18: Timestamp File Update Semantics
+### LA-REQ-004.18: Timestamp File Update Semantics
 
 The `needs_learning_as_of_timestamp` file MUST be overwritten (not appended) each time the same agent is used in the same session. The timestamp reflects the most recent invocation.

--- a/specs/learning-agents/LA-REQ-005-issue-lifecycle.md
+++ b/specs/learning-agents/LA-REQ-005-issue-lifecycle.md
@@ -1,4 +1,4 @@
-# REQ-005: Issue Lifecycle
+# LA-REQ-005: Issue Lifecycle
 
 ## Overview
 
@@ -6,56 +6,56 @@ Issues track problems observed in LearningAgent sessions. They progress through 
 
 ## Requirements
 
-### REQ-005.1: Issue File Location
+### LA-REQ-005.1: Issue File Location
 
 Issue files MUST be stored in the session log folder at `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/`.
 
-### REQ-005.2: Issue File Naming
+### LA-REQ-005.2: Issue File Naming
 
 Issue files MUST be named `<short-name-roughly-describing-issue>.issue.yml`. The short name MUST use dashes, be 3-6 words maximum, and descriptively identify the issue (e.g., `wrong-retry-strategy.issue.yml`).
 
-### REQ-005.3: Issue File Extension
+### LA-REQ-005.3: Issue File Extension
 
 Issue files MUST use the `.issue.yml` extension (not `.yaml` or `.yml` alone).
 
-### REQ-005.4: Status Field -- Required
+### LA-REQ-005.4: Status Field -- Required
 
 Every issue file MUST contain a `status` field. The status field MUST be one of: `identified`, `investigated`, or `learned`.
 
-### REQ-005.5: Status Lifecycle
+### LA-REQ-005.5: Status Lifecycle
 
 Issue status MUST progress through the lifecycle in order: `identified` -> `investigated` -> `learned`. A status MUST NOT be set to a previous stage (no regressions). The status MUST NOT skip stages (e.g., going directly from `identified` to `learned`).
 
-### REQ-005.6: Initial Status
+### LA-REQ-005.6: Initial Status
 
 When an issue file is first created, the `status` field MUST be set to `identified`.
 
-### REQ-005.7: Seen-At Timestamps Field
+### LA-REQ-005.7: Seen-At Timestamps Field
 
 Every issue file MUST contain a `seen_at_timestamps` field as an array of ISO 8601 timestamp strings. Each timestamp represents when the issue manifested (not the root cause location).
 
-### REQ-005.8: Seen-At Timestamps -- Source
+### LA-REQ-005.8: Seen-At Timestamps -- Source
 
 Timestamps in `seen_at_timestamps` MUST be either:
 - The exact timestamp from the transcript line numbers (when reviewing transcript files)
 - The current UTC time (when reporting the issue in real-time)
 
-### REQ-005.9: Issue Description Field
+### LA-REQ-005.9: Issue Description Field
 
 Every issue file MUST contain an `issue_description` field with freeform text. The description MUST describe the observable problem (what went wrong), NOT the root cause (why it happened). It MUST be specific enough that a reader can understand the failure without seeing the transcript.
 
-### REQ-005.10: Investigation Report Field -- Conditional
+### LA-REQ-005.10: Investigation Report Field -- Conditional
 
 The `investigation_report` field MUST NOT be present when the issue is first created (status: `identified`). It MUST be added when the status transitions to `investigated`.
 
-### REQ-005.11: Investigation Report Content
+### LA-REQ-005.11: Investigation Report Content
 
 The `investigation_report` field MUST contain:
 - Specific line numbers from the transcript as evidence
 - An explanation of why the agent behaved incorrectly
 - Identification of the knowledge gap or instruction deficiency that caused the issue
 
-### REQ-005.12: Issue File YAML Structure
+### LA-REQ-005.12: Issue File YAML Structure
 
 The issue file MUST be valid YAML with the following structure:
 ```yaml
@@ -68,6 +68,6 @@ investigation_report: |
   <freeform text, only when investigated or learned>
 ```
 
-### REQ-005.13: No Duplicate Issues
+### LA-REQ-005.13: No Duplicate Issues
 
 The system MUST NOT create duplicate issue files for the same problem within a single session. The identify skill MUST check for existing issues before creating new ones.

--- a/specs/learning-agents/LA-REQ-006-learning-cycle.md
+++ b/specs/learning-agents/LA-REQ-006-learning-cycle.md
@@ -1,4 +1,4 @@
-# REQ-006: Learning Cycle Orchestration
+# LA-REQ-006: Learning Cycle Orchestration
 
 ## Overview
 
@@ -6,25 +6,25 @@ The learning cycle (`/learning-agents learn`) is the top-level orchestrator that
 
 ## Requirements
 
-### REQ-006.1: Skill Invocation
+### LA-REQ-006.1: Skill Invocation
 
 The learning cycle MUST be invocable via `/learning-agents learn`. Arguments after `learn` MUST be ignored.
 
-### REQ-006.2: Automatic Session Discovery
+### LA-REQ-006.2: Automatic Session Discovery
 
 The skill MUST automatically discover all pending sessions by searching for `needs_learning_as_of_timestamp` files under `.deepwork/tmp/agent_sessions/`. The skill MUST NOT require the user to specify which sessions to process.
 
-### REQ-006.3: No Pending Sessions
+### LA-REQ-006.3: No Pending Sessions
 
 If no `needs_learning_as_of_timestamp` files are found (or the `.deepwork/tmp/agent_sessions` directory does not exist), the skill MUST inform the user that there are no pending sessions and stop.
 
-### REQ-006.4: Session Metadata Extraction
+### LA-REQ-006.4: Session Metadata Extraction
 
 For each pending session, the skill MUST extract:
 - The session folder path (parent directory of `needs_learning_as_of_timestamp`)
 - The agent name (from the `agent_used` file in that folder)
 
-### REQ-006.5: Three-Phase Processing
+### LA-REQ-006.5: Three-Phase Processing
 
 For each pending session, the skill MUST run the learning cycle in three sequential phases:
 1. **Identify**: Spawn a Task to run the `identify` skill on the session folder
@@ -33,19 +33,19 @@ For each pending session, the skill MUST run the learning cycle in three sequent
 
 The investigate and incorporate phases MAY be combined into a single Task invocation, but they MUST execute in that order.
 
-### REQ-006.6: Task Tool Usage for Sub-Skills
+### LA-REQ-006.6: Task Tool Usage for Sub-Skills
 
 The identify phase MUST be run as a separate Task invocation. The investigate and incorporate phases MUST be run as a combined Task invocation (investigate first, then incorporate). All Task spawns MUST use the `learning-agents:identify`, `learning-agents:investigate-issues`, and `learning-agents:incorporate-learnings` skills respectively.
 
-### REQ-006.7: Sub-Task Model Selection
+### LA-REQ-006.7: Sub-Task Model Selection
 
 Task spawns for learning cycle sub-skills MUST use the Sonnet model to balance cost and quality.
 
-### REQ-006.8: Sequential Session Processing
+### LA-REQ-006.8: Sequential Session Processing
 
 Sessions MUST be processed one at a time (sequentially, not in parallel) to avoid conflicts when multiple sessions involve the same agent.
 
-### REQ-006.9: Failure Handling
+### LA-REQ-006.9: Failure Handling
 
 If a sub-skill Task fails for a session, the skill MUST:
 - Log the failure
@@ -53,11 +53,11 @@ If a sub-skill Task fails for a session, the skill MUST:
 - Continue processing remaining sessions
 - NOT mark `needs_learning_as_of_timestamp` as resolved for the failed session
 
-### REQ-006.10: Missing Transcript Handling
+### LA-REQ-006.10: Missing Transcript Handling
 
 If a session's transcript cannot be found, the skill MUST skip that session and report the issue in the final summary.
 
-### REQ-006.11: Summary Output
+### LA-REQ-006.11: Summary Output
 
 Upon completion, the skill MUST output a summary containing:
 - Total sessions processed
@@ -66,10 +66,10 @@ Upon completion, the skill MUST output a summary containing:
 - Key learnings per agent
 - Any skipped sessions with reasons
 
-### REQ-006.12: No Direct Agent Modification
+### LA-REQ-006.12: No Direct Agent Modification
 
 The `learn` skill MUST NOT modify agent files directly. All agent knowledge base changes MUST be delegated to the learning cycle sub-skills (identify, investigate-issues, incorporate-learnings).
 
-### REQ-006.13: Dynamic Pending Session List
+### LA-REQ-006.13: Dynamic Pending Session List
 
 The skill MUST use a dynamic include (`!` backtick `find` command) to list pending sessions at invocation time, ensuring it always has the current state of pending sessions.

--- a/specs/learning-agents/LA-REQ-007-issue-identification.md
+++ b/specs/learning-agents/LA-REQ-007-issue-identification.md
@@ -1,4 +1,4 @@
-# REQ-007: Issue Identification
+# LA-REQ-007: Issue Identification
 
 ## Overview
 
@@ -6,42 +6,42 @@ The `identify` skill reads a session transcript and surfaces actionable issues w
 
 ## Requirements
 
-### REQ-007.1: Skill Visibility
+### LA-REQ-007.1: Skill Visibility
 
 The `identify` skill MUST NOT be directly invocable by the user (`user-invocable: false`). It MUST only be invoked programmatically by the `learn` skill via a Task.
 
-### REQ-007.2: Input Argument
+### LA-REQ-007.2: Input Argument
 
 The skill MUST accept a single argument: the path to the session/agent_id folder (e.g., `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/`).
 
-### REQ-007.3: Agent Context Loading
+### LA-REQ-007.3: Agent Context Loading
 
 The skill MUST dynamically load:
 - The agent name from `$ARGUMENTS/agent_used`
 - The last learning timestamp from `$ARGUMENTS/learning_last_performed_timestamp` (if it exists)
 - Additional identification guidelines from `.deepwork/learning-agents/<agent-name>/additional_learning_guidelines/issue_identification.md`
 
-### REQ-007.4: Transcript Location
+### LA-REQ-007.4: Transcript Location
 
 The skill MUST extract the `session_id` from the `$ARGUMENTS` path by taking the second-to-last path component. It MUST then use Glob to find the transcript file at `~/.claude/projects/**/sessions/<session_id>/*.jsonl`.
 
-### REQ-007.5: Missing Transcript
+### LA-REQ-007.5: Missing Transcript
 
 If no transcript file is found, the skill MUST report the error (including the session_id and Glob pattern used) and stop without creating any issue files.
 
-### REQ-007.6: Transcript Format
+### LA-REQ-007.6: Transcript Format
 
 The skill MUST parse the transcript as JSONL (one JSON object per line). Each line has a `type` field. The skill MUST focus on `type: "assistant"` messages and `type: "tool_result"` entries to evaluate agent behavior.
 
-### REQ-007.7: Incremental Processing
+### LA-REQ-007.7: Incremental Processing
 
 If `learning_last_performed_timestamp` exists, the skill MUST skip transcript lines that occurred before that timestamp. Only interactions since the last learning cycle MUST be analyzed.
 
-### REQ-007.8: Agent Focus
+### LA-REQ-007.8: Agent Focus
 
 The skill MUST focus on interactions involving the agent identified in the `agent_used` file. It SHOULD NOT analyze interactions with other agents.
 
-### REQ-007.9: Issue Categories
+### LA-REQ-007.9: Issue Categories
 
 The skill MUST look for these categories of problems:
 1. Incorrect outputs -- wrong answers, broken code, invalid configurations
@@ -50,30 +50,30 @@ The skill MUST look for these categories of problems:
 4. Poor judgment -- questionable decisions or suboptimal approaches
 5. Pattern failures -- repeated errors suggesting a systemic issue
 
-### REQ-007.10: Trivial Issue Filtering
+### LA-REQ-007.10: Trivial Issue Filtering
 
 The skill MUST skip trivial issues including:
 - Minor formatting differences
 - Environmental issues (network timeouts, tool failures)
 - Issues already covered by existing learnings in the agent's knowledge base
 
-### REQ-007.11: Issue Reporting via Sub-Skill
+### LA-REQ-007.11: Issue Reporting via Sub-Skill
 
 For each issue identified, the skill MUST invoke the `report-issue` skill once per issue, passing the session folder path and a one-sentence description of the problem.
 
-### REQ-007.12: No Duplicate Issues
+### LA-REQ-007.12: No Duplicate Issues
 
 The skill MUST NOT create duplicate issue files for the same problem.
 
-### REQ-007.13: No Root Cause Investigation
+### LA-REQ-007.13: No Root Cause Investigation
 
 The skill MUST NOT investigate root causes. Root cause analysis is the responsibility of the `investigate-issues` skill.
 
-### REQ-007.14: No Knowledge Base Modification
+### LA-REQ-007.14: No Knowledge Base Modification
 
 The skill MUST NOT modify the agent's knowledge base (core-knowledge.md, topics, or learnings).
 
-### REQ-007.15: Summary Output
+### LA-REQ-007.15: Summary Output
 
 The skill MUST output a summary containing:
 - Session ID
@@ -82,6 +82,6 @@ The skill MUST output a summary containing:
 - A table listing each issue with its category and a brief description
 - Or a message indicating no actionable issues were found
 
-### REQ-007.16: Allowed Tools
+### LA-REQ-007.16: Allowed Tools
 
 The skill MUST only use the following tools: Read, Grep, Glob, Skill.

--- a/specs/learning-agents/LA-REQ-008-issue-investigation.md
+++ b/specs/learning-agents/LA-REQ-008-issue-investigation.md
@@ -1,4 +1,4 @@
-# REQ-008: Issue Investigation
+# LA-REQ-008: Issue Investigation
 
 ## Overview
 
@@ -6,38 +6,38 @@ The `investigate-issues` skill researches identified issues in a LearningAgent s
 
 ## Requirements
 
-### REQ-008.1: Skill Visibility
+### LA-REQ-008.1: Skill Visibility
 
 The `investigate-issues` skill MUST NOT be directly invocable by the user (`user-invocable: false`). It MUST only be invoked programmatically by the `learn` skill via a Task.
 
-### REQ-008.2: Input Argument
+### LA-REQ-008.2: Input Argument
 
 The skill MUST accept a single argument: the path to the session log folder (e.g., `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/`).
 
-### REQ-008.3: Agent Context Loading
+### LA-REQ-008.3: Agent Context Loading
 
 The skill MUST dynamically load:
 - The agent name from `$ARGUMENTS/agent_used`
 - The agent's core knowledge from `.deepwork/learning-agents/<agent-name>/core-knowledge.md`
 - Additional investigation guidelines from `.deepwork/learning-agents/<agent-name>/additional_learning_guidelines/issue_investigation.md`
 
-### REQ-008.4: Issue Discovery
+### LA-REQ-008.4: Issue Discovery
 
 The skill MUST find all issue files with `status: identified` in the session folder by searching for `*.issue.yml` files containing `status: identified`.
 
-### REQ-008.5: No Identified Issues
+### LA-REQ-008.5: No Identified Issues
 
 If no issue files with status `identified` are found, the skill MUST report that finding and stop.
 
-### REQ-008.6: Transcript Location
+### LA-REQ-008.6: Transcript Location
 
 The skill MUST locate the session transcript using the same mechanism as the identify skill (extract session_id from the path, glob for `~/.claude/projects/**/sessions/<session_id>/*.jsonl`).
 
-### REQ-008.7: Missing Transcript
+### LA-REQ-008.7: Missing Transcript
 
 If no transcript file is found, the skill MUST report the missing path and stop. It MUST NOT proceed to investigate without transcript evidence.
 
-### REQ-008.8: Investigation Process
+### LA-REQ-008.8: Investigation Process
 
 For each identified issue, the skill MUST:
 1. Read the issue file to understand the reported problem
@@ -45,7 +45,7 @@ For each identified issue, the skill MUST:
 3. Determine the root cause
 4. Write an investigation report
 
-### REQ-008.9: Root Cause Taxonomy
+### LA-REQ-008.9: Root Cause Taxonomy
 
 The skill MUST classify root causes using this taxonomy:
 - **Knowledge gap**: Missing or incomplete content in `core-knowledge.md`
@@ -53,40 +53,40 @@ The skill MUST classify root causes using this taxonomy:
 - **Incorrect instruction**: An existing instruction leads the agent to wrong behavior
 - **Missing runtime context**: Information that should have been injected at runtime was absent
 
-### REQ-008.10: Investigation Report Requirements
+### LA-REQ-008.10: Investigation Report Requirements
 
 The investigation report MUST include:
 - Specific evidence from the transcript with line number references
 - Root cause analysis explaining why the agent behaved incorrectly
 - Identification of the knowledge gap or instruction deficiency that caused the issue
 
-### REQ-008.11: Status Update
+### LA-REQ-008.11: Status Update
 
 For each investigated issue, the skill MUST update the issue file to change `status: identified` to `status: investigated`.
 
-### REQ-008.12: Investigation Report Field Addition
+### LA-REQ-008.12: Investigation Report Field Addition
 
 For each investigated issue, the skill MUST add an `investigation_report` field to the issue file containing the root cause analysis.
 
-### REQ-008.13: Issue Description Preservation
+### LA-REQ-008.13: Issue Description Preservation
 
 The skill MUST NOT modify the `issue_description` field. Only the `investigation_report` field MUST be added and the `status` field updated.
 
-### REQ-008.14: Complete Processing
+### LA-REQ-008.14: Complete Processing
 
 The skill MUST NOT skip any identified issues. Every issue file with `status: identified` in the folder MUST be investigated.
 
-### REQ-008.15: No Knowledge Base Modification
+### LA-REQ-008.15: No Knowledge Base Modification
 
 The skill MUST NOT modify the agent's knowledge base. Knowledge base updates are the responsibility of the `incorporate-learnings` skill.
 
-### REQ-008.16: Summary Output
+### LA-REQ-008.16: Summary Output
 
 For each investigated issue, the skill MUST output:
 - The issue filename
 - A one-sentence root cause summary
 - The recommended update type (expertise update, new topic, new learning, or instruction fix)
 
-### REQ-008.17: Allowed Tools
+### LA-REQ-008.17: Allowed Tools
 
 The skill MUST only use the following tools: Read, Grep, Glob, Edit.

--- a/specs/learning-agents/LA-REQ-009-learning-incorporation.md
+++ b/specs/learning-agents/LA-REQ-009-learning-incorporation.md
@@ -1,4 +1,4 @@
-# REQ-009: Learning Incorporation
+# LA-REQ-009: Learning Incorporation
 
 ## Overview
 
@@ -6,40 +6,40 @@ The `incorporate-learnings` skill takes investigated issues and integrates the l
 
 ## Requirements
 
-### REQ-009.1: Skill Visibility
+### LA-REQ-009.1: Skill Visibility
 
 The `incorporate-learnings` skill MUST NOT be directly invocable by the user (`user-invocable: false`). It MUST only be invoked programmatically by the `learn` skill via a Task.
 
-### REQ-009.2: Input Argument
+### LA-REQ-009.2: Input Argument
 
 The skill MUST accept a single argument: the path to the session log folder (e.g., `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/`).
 
-### REQ-009.3: Agent Context Loading
+### LA-REQ-009.3: Agent Context Loading
 
 The skill MUST dynamically load:
 - The agent name from `$ARGUMENTS/agent_used`
 - Additional incorporation guidelines from `.deepwork/learning-agents/<agent-name>/additional_learning_guidelines/learning_from_issues.md`
 
-### REQ-009.4: Unknown Agent Handling
+### LA-REQ-009.4: Unknown Agent Handling
 
 If the `agent_used` file reads "unknown" or is missing, the skill MUST stop and report an error indicating the session folder is missing required metadata.
 
-### REQ-009.5: Issue Discovery
+### LA-REQ-009.5: Issue Discovery
 
 The skill MUST find all issue files with `status: investigated` in the session folder.
 
-### REQ-009.6: No Investigated Issues
+### LA-REQ-009.6: No Investigated Issues
 
 If no investigated issues are found, the skill MUST report that finding and skip to Step 5 (session tracking update). The skill MUST still update tracking files even when there are no issues to incorporate.
 
-### REQ-009.7: Knowledge Base Reading
+### LA-REQ-009.7: Knowledge Base Reading
 
 Before incorporating any issue, the skill MUST read the current state of the agent's knowledge:
 - `.deepwork/learning-agents/<agent-name>/core-knowledge.md`
 - All files in `.deepwork/learning-agents/<agent-name>/topics/`
 - All files in `.deepwork/learning-agents/<agent-name>/learnings/`
 
-### REQ-009.8: Incorporation Strategy Priority
+### LA-REQ-009.8: Incorporation Strategy Priority
 
 The skill MUST evaluate incorporation options in this priority order:
 1. **Amend existing content** (highest priority): If a closely related file already exists in the knowledge base covering the same area, edit that file rather than creating a new one
@@ -48,60 +48,60 @@ The skill MUST evaluate incorporation options in this priority order:
 4. **Add a new learning**: When the narrative context of how the issue unfolded is needed to understand the resolution
 5. **Do nothing**: When the issue would be hard to prevent or is extremely unlikely to recur
 
-### REQ-009.9: Amend Existing Content
+### LA-REQ-009.9: Amend Existing Content
 
 When amending existing content, the skill MUST edit the relevant existing file (topic or learning) rather than creating a new file. The skill MUST NOT create duplicates of existing knowledge.
 
-### REQ-009.10: Core Knowledge Updates
+### LA-REQ-009.10: Core Knowledge Updates
 
 When updating `core-knowledge.md`, the skill MUST keep additions concise (1-2 sentences). Detailed content MUST be moved to topics or learnings instead.
 
-### REQ-009.11: New Topic File Format
+### LA-REQ-009.11: New Topic File Format
 
-When creating a new topic, the file MUST follow the format specified in REQ-003.7, including YAML frontmatter with `name`, optional `keywords`, and `last_updated` set to today's date.
+When creating a new topic, the file MUST follow the format specified in LA-REQ-003.7, including YAML frontmatter with `name`, optional `keywords`, and `last_updated` set to today's date.
 
-### REQ-009.12: New Learning File Format
+### LA-REQ-009.12: New Learning File Format
 
-When creating a new learning, the file MUST follow the format specified in REQ-003.10, including YAML frontmatter with `name`, `last_updated` set to today's date, and `summarized_result`. The body MUST include Context, Investigation, Resolution, and Key Takeaway sections.
+When creating a new learning, the file MUST follow the format specified in LA-REQ-003.10, including YAML frontmatter with `name`, `last_updated` set to today's date, and `summarized_result`. The body MUST include Context, Investigation, Resolution, and Key Takeaway sections.
 
-### REQ-009.13: Cross-Reference for Learnings
+### LA-REQ-009.13: Cross-Reference for Learnings
 
 When adding a learning entry, the skill SHOULD also add a brief note to a related topic with a reference to the learning.
 
-### REQ-009.14: No Duplicate Knowledge
+### LA-REQ-009.14: No Duplicate Knowledge
 
 Before adding new content, the skill MUST check existing knowledge base files to avoid duplicating information that already exists.
 
-### REQ-009.15: No Content Removal
+### LA-REQ-009.15: No Content Removal
 
 The skill MUST NOT remove existing content from the knowledge base unless it is directly contradicted by new evidence from the investigation.
 
-### REQ-009.16: Status Update to Learned
+### LA-REQ-009.16: Status Update to Learned
 
 For each incorporated issue, the skill MUST update the issue file to change `status: investigated` to `status: learned`.
 
-### REQ-009.17: Delete Needs Learning Flag
+### LA-REQ-009.17: Delete Needs Learning Flag
 
 The skill MUST delete the `needs_learning_as_of_timestamp` file from the session folder if it exists, regardless of whether any issues were incorporated.
 
-### REQ-009.18: Update Learning Timestamp
+### LA-REQ-009.18: Update Learning Timestamp
 
 The skill MUST write the current UTC timestamp (ISO 8601 format) to `learning_last_performed_timestamp` in the session folder, regardless of whether any issues were incorporated.
 
-### REQ-009.19: Tracking Update Always Runs
+### LA-REQ-009.19: Tracking Update Always Runs
 
-The session tracking updates (REQ-009.17 and REQ-009.18) MUST always execute, even if no investigated issues were found or if all issues resulted in "do nothing" decisions.
+The session tracking updates (LA-REQ-009.17 and LA-REQ-009.18) MUST always execute, even if no investigated issues were found or if all issues resulted in "do nothing" decisions.
 
-### REQ-009.20: Last Updated Date
+### LA-REQ-009.20: Last Updated Date
 
 When creating or updating topic or learning files, the `last_updated` field MUST be set to today's date in YYYY-MM-DD format.
 
-### REQ-009.21: Summary Output
+### LA-REQ-009.21: Summary Output
 
 The skill MUST output a summary containing:
 - Total issues processed
 - For each issue: the filename and action taken (updated core-knowledge, created topic, created learning, amended existing file, or could not incorporate with reason)
 
-### REQ-009.22: Allowed Tools
+### LA-REQ-009.22: Allowed Tools
 
 The skill MUST only use the following tools: Read, Grep, Glob, Edit, Write.

--- a/specs/learning-agents/LA-REQ-010-issue-reporting.md
+++ b/specs/learning-agents/LA-REQ-010-issue-reporting.md
@@ -1,4 +1,4 @@
-# REQ-010: Issue Reporting
+# LA-REQ-010: Issue Reporting
 
 ## Overview
 
@@ -6,52 +6,52 @@ The `report-issue` skill creates individual issue files documenting problems obs
 
 ## Requirements
 
-### REQ-010.1: Skill Visibility
+### LA-REQ-010.1: Skill Visibility
 
 The `report-issue` skill MUST NOT be directly invocable by the user (`user-invocable: false`). It is invoked by the `identify` skill and routed through the main `/learning-agents report_issue` dispatcher.
 
-### REQ-010.2: Input Arguments
+### LA-REQ-010.2: Input Arguments
 
 The skill MUST accept two arguments:
 - `$0`: Path to the session log folder (e.g., `.deepwork/tmp/agent_sessions/<session_id>/<agent_id>/`)
 - `$1`: Brief description of the issue observed
 
-### REQ-010.3: Missing Folder Path Validation
+### LA-REQ-010.3: Missing Folder Path Validation
 
 If `$0` is not provided or does not point to an existing directory, the skill MUST stop and output: `"Error: session log folder path is required and must be an existing directory."`
 
-### REQ-010.4: Missing Description Validation
+### LA-REQ-010.4: Missing Description Validation
 
 If `$1` is not provided or is empty, the skill MUST stop and output: `"Error: issue description is required."`
 
-### REQ-010.5: Issue Name Derivation
+### LA-REQ-010.5: Issue Name Derivation
 
 The skill MUST derive a kebab-case filename of 3-6 words maximum from the issue description. The name MUST focus on the most distinctive noun and verb from the failure and MUST avoid filler words like "the", "a", "in", "with".
 
-### REQ-010.6: Issue File Creation
+### LA-REQ-010.6: Issue File Creation
 
 The skill MUST create the issue file at `$0/<issue-name>.issue.yml` with the following fields:
 - `status: identified`
 - `seen_at_timestamps`: array containing a single current ISO 8601 UTC timestamp
 - `issue_description`: freeform text derived from the `$1` argument
 
-### REQ-010.7: Issue Description Content
+### LA-REQ-010.7: Issue Description Content
 
 The `issue_description` field MUST focus on the observable problem (symptoms), NOT the root cause. It MUST be specific enough that someone can understand the failure without seeing the transcript.
 
-### REQ-010.8: No Investigation Report
+### LA-REQ-010.8: No Investigation Report
 
 The created issue file MUST NOT include an `investigation_report` field. That field is added during the investigate step.
 
-### REQ-010.9: Status Must Be Identified
+### LA-REQ-010.9: Status Must Be Identified
 
 The `status` field MUST be set to `identified`. The skill MUST NOT set any other status value.
 
-### REQ-010.10: No Other File Modifications
+### LA-REQ-010.10: No Other File Modifications
 
 The skill MUST NOT modify any other files in the session folder or elsewhere. Only the new issue file is created.
 
-### REQ-010.11: Confirmation Output
+### LA-REQ-010.11: Confirmation Output
 
 After creating the issue file, the skill MUST output a two-line confirmation:
 - `Created: <path to the created issue file>`

--- a/specs/learning-agents/LA-REQ-011-skill-routing.md
+++ b/specs/learning-agents/LA-REQ-011-skill-routing.md
@@ -1,4 +1,4 @@
-# REQ-011: Skill Routing and CLI Interface
+# LA-REQ-011: Skill Routing and CLI Interface
 
 ## Overview
 
@@ -6,27 +6,27 @@ The `/learning-agents` skill is the dispatch entry point for the plugin. It rout
 
 ## Requirements
 
-### REQ-011.1: Entry Point Skill
+### LA-REQ-011.1: Entry Point Skill
 
 The plugin MUST provide a top-level skill named `learning-agents` that serves as the dispatch entry point. This skill MUST be user-invocable.
 
-### REQ-011.2: Argument Parsing
+### LA-REQ-011.2: Argument Parsing
 
 The skill MUST split `$ARGUMENTS` on the first whitespace. The first token is the sub-command (case-insensitive); the remainder is passed to the sub-skill.
 
-### REQ-011.3: Underscore-Dash Equivalence
+### LA-REQ-011.3: Underscore-Dash Equivalence
 
 The skill MUST accept both underscores and dashes in sub-command names as equivalent (e.g., `report_issue` and `report-issue` MUST both route to the same sub-skill).
 
-### REQ-011.4: Create Sub-Command
+### LA-REQ-011.4: Create Sub-Command
 
 The `create <name>` sub-command MUST invoke `Skill learning-agents:create-agent <name>`.
 
-### REQ-011.5: Learn Sub-Command
+### LA-REQ-011.5: Learn Sub-Command
 
 The `learn` sub-command MUST invoke `Skill learning-agents:learn`. Arguments after `learn` MUST be ignored.
 
-### REQ-011.6: Report Issue Sub-Command
+### LA-REQ-011.6: Report Issue Sub-Command
 
 The `report_issue <agentId> <details>` sub-command MUST:
 1. Search `.deepwork/tmp/agent_sessions/` for a subdirectory whose name contains the provided `agentId`
@@ -34,26 +34,26 @@ The `report_issue <agentId> <details>` sub-command MUST:
 3. If multiple matches exist, use the most recently modified one
 4. Invoke `Skill learning-agents:report-issue <resolved-path> <details>`
 
-### REQ-011.7: Help Text
+### LA-REQ-011.7: Help Text
 
 When no arguments are provided or input does not match any known sub-command, the skill MUST display a help message listing all available sub-commands with descriptions and examples.
 
-### REQ-011.8: No Inline Implementation
+### LA-REQ-011.8: No Inline Implementation
 
 The skill MUST always route to the appropriate sub-skill. It MUST NOT implement sub-command logic inline.
 
-### REQ-011.9: Argument Pass-Through
+### LA-REQ-011.9: Argument Pass-Through
 
 The skill MUST pass arguments through to sub-skills exactly as provided by the user (after extracting the sub-command token).
 
-### REQ-011.10: Available Sub-Commands
+### LA-REQ-011.10: Available Sub-Commands
 
 The skill MUST support exactly three sub-commands:
 - `create` -- create a new LearningAgent
 - `learn` -- run learning cycle on pending sessions
 - `report_issue` -- report an issue with an agent
 
-### REQ-011.11: Sub-Skill Registry
+### LA-REQ-011.11: Sub-Skill Registry
 
 The plugin MUST provide the following skills, each in its own directory under `skills/`:
 - `learning-agents` -- dispatch entry point
@@ -65,6 +65,6 @@ The plugin MUST provide the following skills, each in its own directory under `s
 - `report-issue` -- issue file creation (non-user-invocable)
 - `prompt-review` -- prompt engineering review (user-invocable)
 
-### REQ-011.12: Prompt Review Skill Independence
+### LA-REQ-011.12: Prompt Review Skill Independence
 
 The `prompt-review` skill MUST be independently invocable (it is NOT routed through the `/learning-agents` dispatcher). It MUST be a separate, standalone skill.

--- a/specs/learning-agents/LA-REQ-012-prompt-review.md
+++ b/specs/learning-agents/LA-REQ-012-prompt-review.md
@@ -1,4 +1,4 @@
-# REQ-012: Prompt Review
+# LA-REQ-012: Prompt Review
 
 ## Overview
 
@@ -6,26 +6,26 @@ The `prompt-review` skill reviews a prompt or instruction file against Anthropic
 
 ## Requirements
 
-### REQ-012.1: Skill Invocation
+### LA-REQ-012.1: Skill Invocation
 
 The skill MUST be user-invocable via `/learning-agents:prompt-review <path>`. If no path argument is provided, the skill MUST ask the user which file to review.
 
-### REQ-012.2: Best Practices Fetch
+### LA-REQ-012.2: Best Practices Fetch
 
 The skill MUST attempt to fetch current Anthropic prompt engineering guidance from `https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview` using WebFetch. If the fetch fails, the skill MUST proceed using built-in knowledge of Anthropic prompt engineering best practices.
 
-### REQ-012.3: File Reading
+### LA-REQ-012.3: File Reading
 
 The skill MUST read the file at the specified path. If the path is relative, it MUST be resolved from the current working directory. If the file does not exist, the skill MUST inform the user and stop.
 
-### REQ-012.4: Prompt Context Determination
+### LA-REQ-012.4: Prompt Context Determination
 
 Before evaluating, the skill MUST identify the prompt context type:
 - **Standalone system prompt**: The file is the complete prompt
 - **Instruction chunk / skill file**: The file is injected into a larger prompt context
 - **Template with variables**: The file contains placeholders or templates filled at runtime
 
-### REQ-012.5: Evaluation Criteria
+### LA-REQ-012.5: Evaluation Criteria
 
 The skill MUST evaluate the file against all of the following criteria:
 1. Clarity and Specificity
@@ -39,11 +39,11 @@ The skill MUST evaluate the file against all of the following criteria:
 9. Variable and Placeholder Usage
 10. Task Decomposition
 
-### REQ-012.6: Per-Criterion Assessment
+### LA-REQ-012.6: Per-Criterion Assessment
 
 For each of the 10 evaluation criteria, the skill MUST assess whether the prompt follows it well, partially, or poorly.
 
-### REQ-012.7: Output Format
+### LA-REQ-012.7: Output Format
 
 The skill MUST produce a review in the following structure:
 - Prompt type classification
@@ -53,7 +53,7 @@ The skill MUST produce a review in the following structure:
 - Issues found (each with severity, related criterion, location, problem description, and recommendation)
 - Summary of recommendations table (priority, description, effort)
 
-### REQ-012.8: Grading Rubric
+### LA-REQ-012.8: Grading Rubric
 
 The skill MUST use the following grading scale:
 - **A**: Follows nearly all best practices. Minor improvements only. Production-ready.
@@ -62,14 +62,14 @@ The skill MUST use the following grading scale:
 - **D**: Significant issues. Missing structure, clarity, or key prompt engineering patterns.
 - **F**: Fundamentally flawed. Needs a rewrite to be effective.
 
-### REQ-012.9: Issue Severity Levels
+### LA-REQ-012.9: Issue Severity Levels
 
 Each issue found MUST be classified with a severity level: Critical, High, Medium, or Low.
 
-### REQ-012.10: Actionable Recommendations
+### LA-REQ-012.10: Actionable Recommendations
 
 Every recommendation MUST point to a concrete line or section in the file and explain exactly what to change. Recommendations SHOULD include before/after examples when helpful.
 
-### REQ-012.11: Allowed Tools
+### LA-REQ-012.11: Allowed Tools
 
 The skill MUST only use the following tools: Read, Glob, Grep, WebFetch.

--- a/tests/e2e/test_claude_code_integration.py
+++ b/tests/e2e/test_claude_code_integration.py
@@ -210,7 +210,7 @@ class TestMCPWorkflowTools:
         # Cleanup
         shutil.rmtree(tmpdir, ignore_errors=True)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.2.3, REQ-001.2.4, REQ-001.2.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.2.3, JOBS-REQ-001.2.4, JOBS-REQ-001.2.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_get_workflows_returns_jobs(self, project_with_job: Path) -> None:
         """Test that get_workflows returns available jobs and workflows."""
@@ -234,7 +234,7 @@ class TestMCPWorkflowTools:
         assert full_workflow.name == "full"
         assert full_workflow.summary is not None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.8, REQ-001.3.10, REQ-001.3.11).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.8, JOBS-REQ-001.3.10, JOBS-REQ-001.3.11).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_workflow_creates_session(self, project_with_job: Path) -> None:
         """Test that start_workflow creates a new workflow session."""
@@ -268,7 +268,7 @@ class TestMCPWorkflowTools:
         assert response.begin_step.step_instructions is not None
         assert len(response.begin_step.step_instructions) > 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.7, REQ-001.4.17).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.7, JOBS-REQ-001.4.17).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_workflow_step_progression(self, project_with_job: Path) -> None:
         """Test that finished_step progresses through workflow steps."""

--- a/tests/integration/test_quality_gate_integration.py
+++ b/tests/integration/test_quality_gate_integration.py
@@ -69,7 +69,7 @@ class TestRealClaudeIntegration:
     actual Claude Code CLI. If you mock them, you defeat their entire purpose.
     """
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.1, REQ-004.2.4, REQ-004.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.2.1, JOBS-REQ-004.2.4, JOBS-REQ-004.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_real_claude_evaluates_passing_criteria(self, project_root: Path) -> None:
         """Test that real Claude CLI correctly evaluates passing criteria.
@@ -111,7 +111,7 @@ class TestRealClaudeIntegration:
             assert len(result.criteria_results) > 0
             pytest.skip(f"Model returned fail (may be model variability): {result.feedback}")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.1, REQ-004.2.4, REQ-004.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.2.1, JOBS-REQ-004.2.4, JOBS-REQ-004.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_real_claude_evaluates_failing_criteria(self, project_root: Path) -> None:
         """Test that real Claude CLI correctly identifies missing criteria.

--- a/tests/unit/jobs/mcp/test_async_interface.py
+++ b/tests/unit/jobs/mcp/test_async_interface.py
@@ -59,7 +59,7 @@ class TestAsyncInterfaceRegression:
             "StateManager._session_stack must be a list for nested workflow support"
         )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.1, REQ-001.4.1, REQ-001.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.1, JOBS-REQ-001.4.1, JOBS-REQ-001.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_workflow_tools_async_methods(self) -> None:
         """Verify WorkflowTools methods that must be async remain async."""

--- a/tests/unit/jobs/mcp/test_claude_cli.py
+++ b/tests/unit/jobs/mcp/test_claude_cli.py
@@ -80,21 +80,21 @@ TEST_SCHEMA: dict[str, Any] = {
 class TestClaudeCLI:
     """Tests for ClaudeCLI class."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.1.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.1.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_init(self) -> None:
         """Test ClaudeCLI initialization."""
         cli = ClaudeCLI(timeout=60)
         assert cli.timeout == 60
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.1.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.1.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_init_defaults(self) -> None:
         """Test ClaudeCLI default values."""
         cli = ClaudeCLI()
         assert cli.timeout == 120
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_run_returns_structured_output(self, tmp_path: Path) -> None:
         """Test that run() returns the structured_output dict."""
@@ -111,7 +111,7 @@ class TestClaudeCLI:
 
         assert result == expected
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_run_pipes_prompt_via_stdin(self, tmp_path: Path) -> None:
         """Test that the prompt is piped via stdin."""
@@ -157,7 +157,7 @@ class TestClaudeCLICommandConstruction:
         flag_index = captured_cmd.index(flag)
         return captured_cmd[flag_index + 1]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.2.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.2.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_command_includes_json_schema(self, tmp_path: Path) -> None:
         """Test that the command includes --json-schema with the correct schema."""
@@ -175,7 +175,7 @@ class TestClaudeCLICommandConstruction:
         parsed_schema = json.loads(schema_json)
         assert parsed_schema == TEST_SCHEMA
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_command_includes_system_prompt(self, tmp_path: Path) -> None:
         """Test that the command includes --system-prompt."""
@@ -192,7 +192,7 @@ class TestClaudeCLICommandConstruction:
         system_prompt = self.get_command_arg(captured_cmd, "--system-prompt")
         assert system_prompt == "You are a reviewer"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.2.1, REQ-009.2.2, REQ-009.2.3, REQ-009.2.6, REQ-009.2.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.2.1, JOBS-REQ-009.2.2, JOBS-REQ-009.2.3, JOBS-REQ-009.2.6, JOBS-REQ-009.2.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_command_has_correct_flag_ordering(self, tmp_path: Path) -> None:
         """Test that flags come before -p -- for proper CLI invocation.
@@ -226,7 +226,7 @@ class TestClaudeCLICommandConstruction:
         assert system_prompt_index < p_index, "Flags must come before -p"
         assert dash_dash_index == p_index + 1, "-- must immediately follow -p"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.1.2, REQ-009.1.3, REQ-009.1.4, REQ-009.2.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.1.2, JOBS-REQ-009.1.3, JOBS-REQ-009.1.4, JOBS-REQ-009.2.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_test_command_override(self, tmp_path: Path) -> None:
         """Test that _test_command overrides the default command."""
@@ -251,7 +251,7 @@ class TestClaudeCLICommandConstruction:
 class TestClaudeCLIWrapperParsing:
     """Tests for Claude CLI response wrapper parsing."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.4.1, REQ-009.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.4.1, JOBS-REQ-009.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_wrapper_valid(self) -> None:
         """Test parsing a valid wrapper response."""
@@ -268,7 +268,7 @@ class TestClaudeCLIWrapperParsing:
         result = cli._parse_wrapper(response)
         assert result == {"value": "hello"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_wrapper_error(self) -> None:
         """Test parsing a wrapper with is_error=True."""
@@ -285,7 +285,7 @@ class TestClaudeCLIWrapperParsing:
         with pytest.raises(ClaudeCLIError, match="returned error"):
             cli._parse_wrapper(response)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_wrapper_missing_structured_output(self) -> None:
         """Test parsing a wrapper missing structured_output field."""
@@ -302,7 +302,7 @@ class TestClaudeCLIWrapperParsing:
         with pytest.raises(ClaudeCLIError, match="missing 'structured_output'"):
             cli._parse_wrapper(response)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_wrapper_invalid_json(self) -> None:
         """Test parsing invalid JSON."""
@@ -315,7 +315,7 @@ class TestClaudeCLIWrapperParsing:
 class TestClaudeCLIErrors:
     """Tests for error handling."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_timeout_error(self, tmp_path: Path) -> None:
         """Test that timeout raises ClaudeCLIError."""
@@ -348,7 +348,7 @@ class TestClaudeCLIErrors:
                     cwd=tmp_path,
                 )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_nonzero_exit_code(self, tmp_path: Path) -> None:
         """Test that non-zero exit code raises ClaudeCLIError."""
@@ -373,7 +373,7 @@ class TestClaudeCLIErrors:
                     cwd=tmp_path,
                 )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-009.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-009.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_command_not_found(self, tmp_path: Path) -> None:
         """Test that missing command raises ClaudeCLIError."""

--- a/tests/unit/jobs/mcp/test_quality_gate.py
+++ b/tests/unit/jobs/mcp/test_quality_gate.py
@@ -46,7 +46,7 @@ def output_file(project_root: Path) -> Path:
 class TestQualityGate:
     """Tests for QualityGate class."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.1, REQ-004.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.1, JOBS-REQ-004.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_init_no_cli(self) -> None:
         """Test QualityGate with no CLI provided has _cli=None and default max_inline_files."""
@@ -54,14 +54,14 @@ class TestQualityGate:
         assert gate._cli is None
         assert gate.max_inline_files == QualityGate.DEFAULT_MAX_INLINE_FILES
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_init_custom_cli(self, mock_cli: ClaudeCLI) -> None:
         """Test QualityGate uses provided ClaudeCLI."""
         gate = QualityGate(cli=mock_cli)
         assert gate._cli is mock_cli
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.2, REQ-004.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.2.2, JOBS-REQ-004.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_build_instructions(self, quality_gate: QualityGate) -> None:
         """Test building system instructions with dict format."""
@@ -80,7 +80,7 @@ class TestQualityGate:
         assert "passed" in instructions  # JSON format mentioned
         assert "feedback" in instructions  # JSON format mentioned
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.10.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.10.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_build_instructions_with_guidance(self, quality_gate: QualityGate) -> None:
         """Test that additional_review_guidance appears in system instructions."""
@@ -92,7 +92,7 @@ class TestQualityGate:
         assert "Additional Context" in instructions
         assert "Read the job.yml file for context." in instructions
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.10.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.10.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_build_instructions_without_guidance(self, quality_gate: QualityGate) -> None:
         """Test that guidance section is absent when not provided."""
@@ -102,7 +102,7 @@ class TestQualityGate:
 
         assert "Additional Context" not in instructions
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.1, REQ-004.3.5, REQ-004.3.6, REQ-004.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.1, JOBS-REQ-004.3.5, JOBS-REQ-004.3.6, JOBS-REQ-004.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload(self, quality_gate: QualityGate, project_root: Path) -> None:
         """Test building payload with file contents."""
@@ -120,7 +120,7 @@ class TestQualityGate:
         assert "BEGIN OUTPUTS" in payload
         assert "END OUTPUTS" in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload_missing_file(
         self, quality_gate: QualityGate, project_root: Path
@@ -134,7 +134,7 @@ class TestQualityGate:
         assert "File not found" in payload
         assert "nonexistent.md" in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.1, REQ-004.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.1, JOBS-REQ-004.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload_files_type(
         self, quality_gate: QualityGate, project_root: Path
@@ -153,7 +153,7 @@ class TestQualityGate:
         assert "a.md" in payload
         assert "b.md" in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload_binary_file(
         self, quality_gate: QualityGate, project_root: Path
@@ -174,7 +174,7 @@ class TestQualityGate:
         # Should NOT contain the raw binary content
         assert "%PDF" not in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.4.2, REQ-004.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.4.2, JOBS-REQ-004.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload_binary_file_in_multi_output(
         self, quality_gate: QualityGate, project_root: Path
@@ -197,7 +197,7 @@ class TestQualityGate:
         assert "not included in review" in payload
         assert str(binary_file.resolve()) in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_build_payload_only_outputs(
         self, quality_gate: QualityGate, project_root: Path
@@ -215,7 +215,7 @@ class TestQualityGate:
         assert "BEGIN INPUTS" not in payload
         assert "END INPUTS" not in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_result_valid(self, quality_gate: QualityGate) -> None:
         """Test parsing valid structured output data."""
@@ -231,7 +231,7 @@ class TestQualityGate:
         assert result.feedback == "All good"
         assert len(result.criteria_results) == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_result_failed(self, quality_gate: QualityGate) -> None:
         """Test parsing failed evaluation data."""
@@ -247,7 +247,7 @@ class TestQualityGate:
         assert result.feedback == "Issues found"
         assert result.criteria_results[0].passed is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parse_result_multiple_criteria(self, quality_gate: QualityGate) -> None:
         """Test that criteria results are properly parsed with multiple entries."""
@@ -272,7 +272,7 @@ class TestQualityGate:
         assert result.criteria_results[2].passed is False
         assert result.criteria_results[2].feedback == "Wrong format"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_evaluate_no_criteria(
         self, quality_gate: QualityGate, project_root: Path
@@ -287,7 +287,7 @@ class TestQualityGate:
         assert result.passed is True
         assert "auto-passing" in result.feedback.lower()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.1, REQ-004.2.2, REQ-004.2.3, REQ-004.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.2.1, JOBS-REQ-004.2.2, JOBS-REQ-004.2.3, JOBS-REQ-004.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_evaluate_calls_cli_with_correct_args(
         self, mock_cli: ClaudeCLI, project_root: Path
@@ -313,7 +313,7 @@ class TestQualityGate:
         assert "Must be valid" in call_kwargs.kwargs["system_prompt"]
         assert "Test content" in call_kwargs.kwargs["prompt"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.6.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_evaluate_wraps_cli_error(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test that ClaudeCLIError is wrapped in QualityGateError."""
@@ -330,7 +330,7 @@ class TestQualityGate:
                 project_root=project_root,
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.4, REQ-004.2.5, REQ-004.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.2.4, JOBS-REQ-004.2.5, JOBS-REQ-004.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_schema_is_valid_json(self) -> None:
         """Test that QUALITY_GATE_RESPONSE_SCHEMA is valid JSON-serializable."""
@@ -345,7 +345,7 @@ class TestQualityGate:
 class TestEvaluateReviews:
     """Tests for QualityGate.evaluate_reviews method."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_empty_reviews(self, quality_gate: QualityGate, project_root: Path) -> None:
         """Test that empty reviews returns empty list."""
@@ -357,7 +357,7 @@ class TestEvaluateReviews:
         )
         assert result == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.3, REQ-004.7.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.3, JOBS-REQ-004.7.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_step_review_passes(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test step-level review that passes."""
@@ -381,7 +381,7 @@ class TestEvaluateReviews:
         )
         assert result == []  # No failures
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_step_review_fails(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test step-level review that fails."""
@@ -413,7 +413,7 @@ class TestEvaluateReviews:
         assert result[0].review_run_each == "step"
         assert result[0].passed is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_per_file_review(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test per-file review for files-type output."""
@@ -444,7 +444,7 @@ class TestEvaluateReviews:
         assert result == []  # All pass
         assert call_count == 2  # Called once per file
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_single_file_review(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test review targeting a single-file output."""
@@ -469,7 +469,7 @@ class TestEvaluateReviews:
         assert result == []
         mock_cli.run.assert_called_once()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_review_passes_guidance_to_system_prompt(
         self, mock_cli: ClaudeCLI, project_root: Path
@@ -500,7 +500,7 @@ class TestEvaluateReviews:
         assert "Read the job.yml for workflow context." in system_prompt
         assert "Additional Context" in system_prompt
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_review_without_guidance_omits_section(
         self, mock_cli: ClaudeCLI, project_root: Path
@@ -528,7 +528,7 @@ class TestEvaluateReviews:
         system_prompt = mock_cli.run.call_args.kwargs["system_prompt"]
         assert "Additional Context" not in system_prompt
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.4, REQ-004.7.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.7.4, JOBS-REQ-004.7.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_per_file_review_passes_guidance_to_each(
         self, mock_cli: ClaudeCLI, project_root: Path
@@ -564,7 +564,7 @@ class TestEvaluateReviews:
 class TestBuildPayloadLargeFileSet:
     """Tests for _build_payload behavior when file count exceeds max_inline_files."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.2, REQ-004.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.2, JOBS-REQ-004.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_payload_lists_paths_when_over_threshold(
         self, quality_gate: QualityGate, project_root: Path
@@ -586,7 +586,7 @@ class TestBuildPayloadLargeFileSet:
         assert "Content 0" not in payload
         assert "Content 5" not in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_payload_inlines_content_at_threshold(
         self, quality_gate: QualityGate, project_root: Path
@@ -605,7 +605,7 @@ class TestBuildPayloadLargeFileSet:
         for i in range(5):
             assert f"Content {i}" in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_path_listing_includes_output_names(
         self, quality_gate: QualityGate, project_root: Path
@@ -628,7 +628,7 @@ class TestBuildPayloadLargeFileSet:
         assert "(output: docs)" in payload
         assert "(output: data)" in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_path_listing_counts_across_outputs(
         self, quality_gate: QualityGate, project_root: Path
@@ -654,14 +654,14 @@ class TestBuildPayloadLargeFileSet:
 class TestBuildPathListing:
     """Tests for _build_path_listing static method."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_single_file_output(self) -> None:
         """Test path listing with single file outputs."""
         lines = QualityGate._build_path_listing({"report": "report.md"})
         assert lines == ["- report.md  (output: report)"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_multi_file_output(self) -> None:
         """Test path listing with list outputs."""
@@ -671,7 +671,7 @@ class TestBuildPathListing:
             "- b.md  (output: reports)",
         ]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_mixed_outputs(self) -> None:
         """Test path listing with both single and list outputs."""
@@ -690,7 +690,7 @@ class TestBuildPathListing:
 class TestComputeTimeout:
     """Tests for QualityGate.compute_timeout."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.8.1, REQ-004.8.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.8.1, JOBS-REQ-004.8.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_base_timeout_for_few_files(self) -> None:
         """Test that <=5 files gives base 240s (4 min) timeout."""
@@ -698,7 +698,7 @@ class TestComputeTimeout:
         assert QualityGate.compute_timeout(1) == 240
         assert QualityGate.compute_timeout(5) == 240
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_timeout_increases_after_five(self) -> None:
         """Test that each file after 5 adds 30 seconds."""
@@ -710,7 +710,7 @@ class TestComputeTimeout:
 class TestDynamicTimeout:
     """Tests that evaluate passes dynamic timeout to CLI."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.3, REQ-004.8.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.6.3, JOBS-REQ-004.8.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_timeout_passed_to_cli(self, mock_cli: ClaudeCLI, project_root: Path) -> None:
         """Test that evaluate passes computed timeout to CLI.run."""
@@ -728,7 +728,7 @@ class TestDynamicTimeout:
         # 1 file -> timeout = 240
         assert call_kwargs["timeout"] == 240
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.3, REQ-004.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.6.3, JOBS-REQ-004.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_timeout_scales_with_file_count(
         self, mock_cli: ClaudeCLI, project_root: Path
@@ -836,7 +836,7 @@ class TestMockQualityGate:
 class TestConfigurableMaxInlineFiles:
     """Tests for configurable max_inline_files on QualityGate."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_default_max_inline_files(self) -> None:
         """Test QualityGate defaults to DEFAULT_MAX_INLINE_FILES."""
@@ -844,7 +844,7 @@ class TestConfigurableMaxInlineFiles:
         assert gate.max_inline_files == QualityGate.DEFAULT_MAX_INLINE_FILES
         assert gate.max_inline_files == 5
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_custom_max_inline_files(self) -> None:
         """Test QualityGate respects explicit max_inline_files."""
@@ -856,14 +856,14 @@ class TestConfigurableMaxInlineFiles:
         gate = QualityGate(max_inline_files=0)
         assert gate.max_inline_files == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_max_inline_files_none_uses_default(self) -> None:
         """Test that passing None explicitly uses the default."""
         gate = QualityGate(max_inline_files=None)
         assert gate.max_inline_files == QualityGate.DEFAULT_MAX_INLINE_FILES
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.1, REQ-004.1.2, REQ-004.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.1, JOBS-REQ-004.1.2, JOBS-REQ-004.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_cli_and_max_inline_files_independent(self, mock_cli: ClaudeCLI) -> None:
         """Test that cli and max_inline_files are independent parameters."""
@@ -871,7 +871,7 @@ class TestConfigurableMaxInlineFiles:
         assert gate._cli is mock_cli
         assert gate.max_inline_files == 3
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_zero_max_inline_always_lists_paths(self, project_root: Path) -> None:
         """Test that max_inline_files=0 uses path listing even for 1 file."""
@@ -887,7 +887,7 @@ class TestConfigurableMaxInlineFiles:
         assert "single.md" in payload
         assert "Single file content" not in payload
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_high_max_inline_embeds_many_files(self, project_root: Path) -> None:
         """Test that a high max_inline_files embeds content for many files."""
@@ -908,7 +908,7 @@ class TestConfigurableMaxInlineFiles:
 class TestEvaluateWithoutCli:
     """Tests that evaluate() raises when no CLI is configured."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.6, REQ-004.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.1.6, JOBS-REQ-004.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_evaluate_raises_without_cli(self, project_root: Path) -> None:
         """Test that evaluate raises QualityGateError when _cli is None."""
@@ -922,7 +922,7 @@ class TestEvaluateWithoutCli:
                 project_root=project_root,
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_evaluate_no_criteria_still_passes_without_cli(self, project_root: Path) -> None:
         """Test that empty criteria auto-passes even without CLI."""
@@ -941,7 +941,7 @@ class TestEvaluateWithoutCli:
 class TestBuildReviewInstructionsFile:
     """Tests for QualityGate.build_review_instructions_file method."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.1, REQ-004.5.6, REQ-004.5.7, REQ-004.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.1, JOBS-REQ-004.5.6, JOBS-REQ-004.5.7, JOBS-REQ-004.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_basic_structure(self, project_root: Path) -> None:
         """Test that the instructions file has the expected structure."""
@@ -971,7 +971,7 @@ class TestBuildReviewInstructionsFile:
         assert "PASS" in content
         assert "FAIL" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_contains_all_criteria(self, project_root: Path) -> None:
         """Test that all criteria from all reviews appear in the file."""
@@ -998,7 +998,7 @@ class TestBuildReviewInstructionsFile:
         assert "**Completeness**" in content
         assert "Is all data present?" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_multiple_reviews_numbered(self, project_root: Path) -> None:
         """Test that multiple reviews get numbered sections."""
@@ -1026,7 +1026,7 @@ class TestBuildReviewInstructionsFile:
         assert "scope: all outputs together" in content
         assert "scope: output 'report'" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_single_review_not_numbered(self, project_root: Path) -> None:
         """Test that a single review uses 'Criteria to Evaluate' heading."""
@@ -1048,7 +1048,7 @@ class TestBuildReviewInstructionsFile:
         assert "## Criteria to Evaluate" in content
         assert "Review 1" not in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.9, REQ-004.10.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.9, JOBS-REQ-004.10.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_includes_author_notes(self, project_root: Path) -> None:
         """Test that notes are included when provided."""
@@ -1071,7 +1071,7 @@ class TestBuildReviewInstructionsFile:
         assert "## Author Notes" in content
         assert "I focused on section 3 the most." in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_excludes_notes_when_none(self, project_root: Path) -> None:
         """Test that notes section is absent when not provided."""
@@ -1092,7 +1092,7 @@ class TestBuildReviewInstructionsFile:
 
         assert "## Author Notes" not in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.5, REQ-004.10.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.5, JOBS-REQ-004.10.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_includes_guidance(self, project_root: Path) -> None:
         """Test that additional_review_guidance is included."""
@@ -1115,7 +1115,7 @@ class TestBuildReviewInstructionsFile:
         assert "### Additional Context" in content
         assert "Also read config.yml for context." in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_per_file_review_lists_files(self, project_root: Path) -> None:
         """Test that per-file reviews list each file to evaluate."""
@@ -1139,7 +1139,7 @@ class TestBuildReviewInstructionsFile:
         assert "a.md" in content
         assert "b.md" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-004.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_output_paths_listed_not_inlined_at_zero(self, project_root: Path) -> None:
         """Test that with max_inline_files=0, file contents are NOT embedded."""

--- a/tests/unit/jobs/mcp/test_schemas.py
+++ b/tests/unit/jobs/mcp/test_schemas.py
@@ -448,7 +448,7 @@ class TestFinishedStepResponse:
 class TestStepProgress:
     """Tests for StepProgress model."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.18.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.18.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_new_step(self) -> None:
         """Test new step progress."""
@@ -464,7 +464,7 @@ class TestStepProgress:
 class TestWorkflowSession:
     """Tests for WorkflowSession model."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.18.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.18.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_basic_session(self) -> None:
         """Test basic session creation."""
@@ -482,7 +482,7 @@ class TestWorkflowSession:
         assert session.status == "active"
         assert session.completed_at is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.18.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.18.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_to_dict(self) -> None:
         """Test converting session to dict."""
@@ -501,7 +501,7 @@ class TestWorkflowSession:
         assert data["session_id"] == "abc123"
         assert data["job_name"] == "test_job"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.18.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.18.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict(self) -> None:
         """Test creating session from dict."""

--- a/tests/unit/jobs/mcp/test_state.py
+++ b/tests/unit/jobs/mcp/test_state.py
@@ -25,7 +25,7 @@ def state_manager(project_root: Path) -> StateManager:
 class TestStateManager:
     """Tests for StateManager class."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_init(self, state_manager: StateManager, project_root: Path) -> None:
         """Test StateManager initialization."""
@@ -34,7 +34,7 @@ class TestStateManager:
         assert state_manager._session_stack == []
         assert state_manager.get_stack_depth() == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.1, REQ-003.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.2.1, JOBS-REQ-003.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_generate_session_id(self, state_manager: StateManager) -> None:
         """Test session ID generation."""
@@ -43,7 +43,7 @@ class TestStateManager:
         assert isinstance(session_id, str)
         assert len(session_id) == 8
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.3.4, REQ-003.3.5, REQ-003.3.8, REQ-003.3.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.3.4, JOBS-REQ-003.3.5, JOBS-REQ-003.3.8, JOBS-REQ-003.3.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_create_session(self, state_manager: StateManager) -> None:
         """Test creating a new session."""
@@ -66,7 +66,7 @@ class TestStateManager:
         session_file = state_manager._session_file(session.session_id)
         assert session_file.exists()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.5.1, REQ-003.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.5.1, JOBS-REQ-003.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_load_session(self, state_manager: StateManager) -> None:
         """Test loading an existing session."""
@@ -86,14 +86,14 @@ class TestStateManager:
         assert loaded_session.job_name == "test_job"
         assert loaded_session.goal == "Complete the task"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_load_session_not_found(self, state_manager: StateManager) -> None:
         """Test loading non-existent session."""
         with pytest.raises(StateError, match="Session not found"):
             await state_manager.load_session("nonexistent")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_get_active_session(self, state_manager: StateManager) -> None:
         """Test getting active session."""
@@ -110,14 +110,14 @@ class TestStateManager:
 
         assert state_manager.get_active_session() == session
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.6.2, REQ-003.6.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.6.2, JOBS-REQ-003.6.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_require_active_session(self, state_manager: StateManager) -> None:
         """Test require_active_session raises when no session."""
         with pytest.raises(StateError, match="No active workflow session"):
             state_manager.require_active_session()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.8.1, REQ-003.8.2, REQ-003.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.8.1, JOBS-REQ-003.8.2, JOBS-REQ-003.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_step(self, state_manager: StateManager) -> None:
         """Test marking a step as started."""
@@ -136,7 +136,7 @@ class TestStateManager:
         assert "step2" in session.step_progress
         assert session.step_progress["step2"].started_at is not None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.8.5, REQ-003.8.6, REQ-003.8.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.8.5, JOBS-REQ-003.8.6, JOBS-REQ-003.8.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_complete_step(self, state_manager: StateManager) -> None:
         """Test marking a step as completed."""
@@ -161,7 +161,7 @@ class TestStateManager:
         assert progress.outputs == {"report": "output1.md", "data": "output2.md"}
         assert progress.notes == "Done!"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.9.1, REQ-003.9.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.9.1, JOBS-REQ-003.9.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_record_quality_attempt(self, state_manager: StateManager) -> None:
         """Test recording quality gate attempts."""
@@ -180,7 +180,7 @@ class TestStateManager:
         attempts = await state_manager.record_quality_attempt("step1")
         assert attempts == 2
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.10.1, REQ-003.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.10.1, JOBS-REQ-003.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_advance_to_step(self, state_manager: StateManager) -> None:
         """Test advancing to a new step."""
@@ -198,7 +198,7 @@ class TestStateManager:
         assert session.current_step_id == "step2"
         assert session.current_entry_index == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.11.1, REQ-003.11.2, REQ-003.11.3, REQ-003.11.4, REQ-003.11.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.11.1, JOBS-REQ-003.11.2, JOBS-REQ-003.11.3, JOBS-REQ-003.11.4, JOBS-REQ-003.11.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_complete_workflow(self, state_manager: StateManager) -> None:
         """Test marking workflow as complete pops from stack."""
@@ -223,7 +223,7 @@ class TestStateManager:
         assert loaded.status == "completed"
         assert loaded.completed_at is not None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.14.1, REQ-003.14.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.14.1, JOBS-REQ-003.14.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_get_all_outputs(self, state_manager: StateManager) -> None:
         """Test getting all outputs from completed steps."""
@@ -245,7 +245,7 @@ class TestStateManager:
         }
         assert len(outputs) == 2
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.15.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.15.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_list_sessions(self, state_manager: StateManager) -> None:
         """Test listing all sessions."""
@@ -270,7 +270,7 @@ class TestStateManager:
         assert "job1" in job_names
         assert "job2" in job_names
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.15.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.15.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_find_active_sessions_for_workflow(self, state_manager: StateManager) -> None:
         """Test finding active sessions for a workflow."""
@@ -293,7 +293,7 @@ class TestStateManager:
         assert len(sessions) == 1
         assert sessions[0].workflow_name == "main"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.16.1, REQ-003.16.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.16.1, JOBS-REQ-003.16.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_delete_session(self, state_manager: StateManager) -> None:
         """Test deleting a session."""
@@ -329,7 +329,7 @@ class TestStateManagerStack:
         """Create a StateManager instance."""
         return StateManager(project_root)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.13.1, REQ-003.13.2, REQ-003.13.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.13.1, JOBS-REQ-003.13.2, JOBS-REQ-003.13.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_nested_workflows_stack(self, state_manager: StateManager) -> None:
         """Test that starting workflows pushes onto the stack."""
@@ -366,7 +366,7 @@ class TestStateManagerStack:
         assert state_manager.get_stack_depth() == 3
         assert state_manager.get_active_session() == session3
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.11.4, REQ-003.11.5, REQ-003.13.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.11.4, JOBS-REQ-003.11.5, JOBS-REQ-003.13.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_complete_workflow_pops_stack(self, state_manager: StateManager) -> None:
         """Test that completing a workflow pops from stack and resumes parent."""
@@ -393,7 +393,7 @@ class TestStateManagerStack:
         assert resumed == session1
         assert state_manager.get_active_session() == session1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.13.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.13.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_get_stack(self, state_manager: StateManager) -> None:
         """Test get_stack returns workflow/step info."""
@@ -418,7 +418,7 @@ class TestStateManagerStack:
         assert stack[1].workflow == "job2/wf2"
         assert stack[1].step == "stepA"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.12.1, REQ-003.12.2, REQ-003.12.3, REQ-003.12.5, REQ-003.12.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.12.1, JOBS-REQ-003.12.2, JOBS-REQ-003.12.3, JOBS-REQ-003.12.5, JOBS-REQ-003.12.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_abort_workflow(self, state_manager: StateManager) -> None:
         """Test abort_workflow marks as aborted and pops from stack."""
@@ -445,7 +445,7 @@ class TestStateManagerStack:
         assert state_manager.get_stack_depth() == 1
         assert state_manager.get_active_session() == session1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.12.2, REQ-003.12.5, REQ-003.12.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.12.2, JOBS-REQ-003.12.5, JOBS-REQ-003.12.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_abort_workflow_no_parent(self, state_manager: StateManager) -> None:
         """Test abort_workflow with no parent workflow."""
@@ -481,7 +481,7 @@ class TestSessionIdRouting:
         """Create a StateManager instance."""
         return StateManager(project_root)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_resolve_session_by_id(self, state_manager: StateManager) -> None:
         """Test _resolve_session finds the correct session in a multi-session stack."""
@@ -506,7 +506,7 @@ class TestSessionIdRouting:
         assert resolved.session_id == middle_session.session_id
         assert resolved.job_name == "job2"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_resolve_session_invalid_id(self, state_manager: StateManager) -> None:
         """Test _resolve_session raises StateError for unknown session ID."""
@@ -521,7 +521,7 @@ class TestSessionIdRouting:
         with pytest.raises(StateError, match="Session 'nonexistent' not found"):
             state_manager._resolve_session("nonexistent")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_resolve_session_none_falls_back_to_active(self, state_manager: StateManager) -> None:
         """Test _resolve_session with None falls back to top-of-stack."""
@@ -541,7 +541,7 @@ class TestSessionIdRouting:
         resolved = state_manager._resolve_session(None)
         assert resolved.job_name == "job2"  # top-of-stack
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.4, REQ-003.11.4, REQ-003.13.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.4, JOBS-REQ-003.11.4, JOBS-REQ-003.13.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_complete_workflow_by_session_id(self, state_manager: StateManager) -> None:
         """Test complete_workflow removes a specific session from middle of stack."""
@@ -570,7 +570,7 @@ class TestSessionIdRouting:
         assert session2.session_id not in remaining_ids
         assert session3.session_id in remaining_ids
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.4, REQ-003.12.2, REQ-003.12.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.4, JOBS-REQ-003.12.2, JOBS-REQ-003.12.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_abort_workflow_by_session_id(self, state_manager: StateManager) -> None:
         """Test abort_workflow removes a specific session from middle of stack."""
@@ -599,7 +599,7 @@ class TestSessionIdRouting:
         assert session1.session_id in remaining_ids
         assert session2.session_id not in remaining_ids
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.7.4, REQ-003.8.5, REQ-003.8.6, REQ-003.8.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-003.7.4, JOBS-REQ-003.8.5, JOBS-REQ-003.8.6, JOBS-REQ-003.8.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_complete_step_with_session_id(self, state_manager: StateManager) -> None:
         """Test complete_step operates on a non-top session when session_id is given."""

--- a/tests/unit/jobs/mcp/test_tools.py
+++ b/tests/unit/jobs/mcp/test_tools.py
@@ -127,7 +127,7 @@ class TestWorkflowTools:
         """Test WorkflowTools initialization."""
         assert tools.project_root == project_root
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.2.3, REQ-001.2.4, REQ-001.2.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.2.3, JOBS-REQ-001.2.4, JOBS-REQ-001.2.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_get_workflows(self, tools: WorkflowTools) -> None:
         """Test getting all workflows."""
@@ -158,7 +158,7 @@ class TestWorkflowTools:
 
         assert len(response.jobs) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.2, REQ-001.3.3, REQ-001.3.9, REQ-001.3.10, REQ-001.3.11, REQ-001.3.13, REQ-001.3.14).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.2, JOBS-REQ-001.3.3, JOBS-REQ-001.3.9, JOBS-REQ-001.3.10, JOBS-REQ-001.3.11, JOBS-REQ-001.3.13, JOBS-REQ-001.3.14).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_workflow(self, tools: WorkflowTools) -> None:
         """Test starting a workflow."""
@@ -183,7 +183,7 @@ class TestWorkflowTools:
         assert response.begin_step.step_reviews[0].run_each == "step"
         assert "Output Valid" in response.begin_step.step_reviews[0].quality_criteria
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_workflow_invalid_job(self, tools: WorkflowTools) -> None:
         """Test starting workflow with invalid job."""
@@ -196,7 +196,7 @@ class TestWorkflowTools:
         with pytest.raises(ToolError, match="Job not found"):
             await tools.start_workflow(input_data)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_workflow_auto_selects_single_workflow(self, tools: WorkflowTools) -> None:
         """Test that a wrong workflow name auto-selects when job has one workflow."""
@@ -210,7 +210,7 @@ class TestWorkflowTools:
         response = await tools.start_workflow(input_data)
         assert response.begin_step.step_id == "step1"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_start_workflow_invalid_workflow_multiple(
         self, project_root: Path, state_manager: StateManager
@@ -274,7 +274,7 @@ workflows:
         with pytest.raises(ToolError, match="Workflow.*not found.*alpha.*beta"):
             await tools.start_workflow(input_data)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_no_session(self, tools: WorkflowTools) -> None:
         """Test finished_step without active session."""
@@ -283,7 +283,7 @@ workflows:
         with pytest.raises(StateError, match="No active workflow session"):
             await tools.finished_step(input_data)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.7, REQ-001.4.15, REQ-001.4.17).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.7, JOBS-REQ-001.4.15, JOBS-REQ-001.4.17).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_advances_to_next(
         self, tools: WorkflowTools, project_root: Path
@@ -313,7 +313,7 @@ workflows:
         assert response.begin_step.step_instructions is not None
         assert "Step 2" in response.begin_step.step_instructions
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.15, REQ-001.4.16).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.15, JOBS-REQ-001.4.16).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_completes_workflow(
         self, tools: WorkflowTools, project_root: Path
@@ -344,7 +344,7 @@ workflows:
         assert "output1.md" in response.all_outputs
         assert "output2.md" in response.all_outputs
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.8, REQ-001.4.14).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.8, JOBS-REQ-001.4.14).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_with_quality_gate_pass(
         self, tools_with_quality: WorkflowTools, project_root: Path
@@ -367,7 +367,7 @@ workflows:
         # Should advance to next step
         assert response.status == StepStatus.NEXT_STEP
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.8, REQ-001.4.11, REQ-001.4.12).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.8, JOBS-REQ-001.4.11, JOBS-REQ-001.4.12).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_with_quality_gate_fail(
         self, project_root: Path, state_manager: StateManager
@@ -399,7 +399,7 @@ workflows:
         assert response.feedback == "Needs improvement"
         assert response.failed_reviews is not None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.13).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.13).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_quality_gate_max_attempts(
         self, project_root: Path, state_manager: StateManager
@@ -434,7 +434,7 @@ workflows:
         with pytest.raises(ToolError, match="Quality gate failed after.*attempts"):
             await tools.finished_step(FinishedStepInput(outputs={"output1.md": "output1.md"}))
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_quality_gate_override(
         self, project_root: Path, state_manager: StateManager
@@ -471,7 +471,7 @@ workflows:
         # Quality gate should not have been called
         assert len(failing_gate.evaluations) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_unknown_output_keys(
         self, tools: WorkflowTools, project_root: Path
@@ -492,7 +492,7 @@ workflows:
                 FinishedStepInput(outputs={"output1.md": "output1.md", "extra.md": "extra.md"})
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_missing_output_keys(
         self, tools: WorkflowTools, project_root: Path
@@ -509,7 +509,7 @@ workflows:
         with pytest.raises(ToolError, match="Missing required outputs.*output1.md"):
             await tools.finished_step(FinishedStepInput(outputs={}))
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_allows_omitting_optional_outputs(
         self, project_root: Path, state_manager: StateManager
@@ -576,7 +576,7 @@ workflows:
 
         assert response.status == StepStatus.WORKFLOW_COMPLETE
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.2, REQ-001.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.2, JOBS-REQ-001.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_rejects_missing_required_but_not_optional(
         self, project_root: Path, state_manager: StateManager
@@ -638,7 +638,7 @@ workflows:
                 FinishedStepInput(outputs={"optional_output.md": "optional_output.md"})
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_accepts_optional_outputs_when_provided(
         self, project_root: Path, state_manager: StateManager
@@ -702,7 +702,7 @@ workflows:
 
         assert response.status == StepStatus.WORKFLOW_COMPLETE
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.13).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.3.13).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_expected_outputs_include_required_field(
         self, project_root: Path, state_manager: StateManager
@@ -766,7 +766,7 @@ workflows:
         assert required_out.required is True
         assert optional_out.required is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_file_type_must_be_string(
         self, tools: WorkflowTools, project_root: Path
@@ -784,7 +784,7 @@ workflows:
         with pytest.raises(ToolError, match="type 'file'.*single string path"):
             await tools.finished_step(FinishedStepInput(outputs={"output1.md": ["output1.md"]}))
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_file_existence(
         self, tools: WorkflowTools, project_root: Path
@@ -850,7 +850,7 @@ workflows:
 
         assert response.status == StepStatus.WORKFLOW_COMPLETE
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_files_type_output(
         self, project_root: Path, state_manager: StateManager
@@ -905,7 +905,7 @@ workflows:
         with pytest.raises(ToolError, match="type 'files'.*list of paths"):
             await tools.finished_step(FinishedStepInput(outputs={"reports": "report1.md"}))
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_validates_files_type_existence(
         self, project_root: Path, state_manager: StateManager
@@ -963,7 +963,7 @@ workflows:
                 FinishedStepInput(outputs={"reports": ["report1.md", "missing.md"]})
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.6, REQ-001.5.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.5.6, JOBS-REQ-001.5.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_files_type_success(
         self, project_root: Path, state_manager: StateManager
@@ -1370,7 +1370,7 @@ workflows:
     def tools(self, project_root: Path, state_manager: StateManager) -> WorkflowTools:
         return WorkflowTools(project_root=project_root, state_manager=state_manager)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_finished_step_with_session_id_not_on_top(
         self, tools: WorkflowTools, project_root: Path
@@ -1412,7 +1412,7 @@ workflows:
         assert top_session.session_id == session_b_id
         assert top_session.current_step_id == "b_step1"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.6.3, REQ-001.6.5, REQ-001.6.6, REQ-001.6.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.6.3, JOBS-REQ-001.6.5, JOBS-REQ-001.6.6, JOBS-REQ-001.6.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_abort_workflow_with_session_id(
         self, tools: WorkflowTools, project_root: Path
@@ -1461,7 +1461,7 @@ class TestExternalRunnerSelfReview:
             external_runner=None,
         )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_returns_needs_work(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1479,7 +1479,7 @@ class TestExternalRunnerSelfReview:
         assert response.status == StepStatus.NEEDS_WORK
         assert response.failed_reviews is None  # No actual review results yet
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_feedback_contains_instructions(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1499,7 +1499,7 @@ class TestExternalRunnerSelfReview:
         assert "quality_review_override_reason" in response.feedback
         assert ".deepwork/tmp/quality_review_" in response.feedback
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_writes_instructions_file(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1517,7 +1517,7 @@ class TestExternalRunnerSelfReview:
         review_files = list((project_root / ".deepwork" / "tmp").glob("quality_review_*.md"))
         assert len(review_files) == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_file_contains_criteria(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1558,7 +1558,7 @@ class TestExternalRunnerSelfReview:
         assert "output1.md" in content
         assert "UNIQUE_CONTENT_MARKER_12345" not in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_file_named_with_session_and_step(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1577,7 +1577,7 @@ class TestExternalRunnerSelfReview:
         expected_file = project_root / ".deepwork" / "tmp" / f"quality_review_{session_id}_step1.md"
         assert expected_file.exists()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.9, REQ-001.4.10).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.9, JOBS-REQ-001.4.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_then_override_completes_workflow(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1604,7 +1604,7 @@ class TestExternalRunnerSelfReview:
         assert resp2.status == StepStatus.NEXT_STEP
         assert resp2.begin_step.step_id == "step2"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_self_review_skipped_for_steps_without_reviews(
         self, tools_self_review: WorkflowTools, project_root: Path
@@ -1654,7 +1654,7 @@ class TestExternalRunnerSelfReview:
 class TestExternalRunnerClaude:
     """Tests that external_runner='claude' uses subprocess evaluation (existing behavior)."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.8, REQ-001.4.14).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.8, JOBS-REQ-001.4.14).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_claude_runner_calls_quality_gate_evaluate(
         self, project_root: Path, state_manager: StateManager
@@ -1703,7 +1703,7 @@ class TestExternalRunnerClaude:
         review_files = list((project_root / ".deepwork" / "tmp").glob("quality_review_*.md"))
         assert len(review_files) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.12).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.12).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_claude_runner_failing_gate_returns_feedback(
         self, project_root: Path, state_manager: StateManager
@@ -1731,7 +1731,7 @@ class TestExternalRunnerClaude:
         assert response.failed_reviews is not None
         assert len(response.failed_reviews) == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.11, REQ-001.4.13).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.4.11, JOBS-REQ-001.4.13).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     async def test_claude_runner_records_quality_attempts(
         self, project_root: Path, state_manager: StateManager
@@ -1765,7 +1765,7 @@ class TestExternalRunnerClaude:
 class TestExternalRunnerInit:
     """Tests for external_runner parameter on WorkflowTools initialization."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_default_external_runner_is_none(
         self, project_root: Path, state_manager: StateManager
@@ -1777,7 +1777,7 @@ class TestExternalRunnerInit:
         )
         assert tools.external_runner is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_explicit_external_runner(
         self, project_root: Path, state_manager: StateManager
@@ -1790,7 +1790,7 @@ class TestExternalRunnerInit:
         )
         assert tools.external_runner == "claude"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.1.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-001.1.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_no_quality_gate_no_external_runner_skips_review(
         self, project_root: Path, state_manager: StateManager

--- a/tests/unit/jobs/test_discovery.py
+++ b/tests/unit/jobs/test_discovery.py
@@ -47,13 +47,13 @@ workflows:
 class TestGetJobFolders:
     """Tests for get_job_folders."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_default_folders_include_project_jobs(self, tmp_path: Path) -> None:
         folders = get_job_folders(tmp_path)
         assert tmp_path / ".deepwork" / "jobs" in folders
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.3, REQ-008.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.1.3, JOBS-REQ-008.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_default_folders_include_standard_jobs(self, tmp_path: Path) -> None:
         from deepwork.jobs.discovery import _STANDARD_JOBS_DIR
@@ -61,7 +61,7 @@ class TestGetJobFolders:
         folders = get_job_folders(tmp_path)
         assert _STANDARD_JOBS_DIR in folders
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.5, REQ-008.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.1.5, JOBS-REQ-008.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_env_var_appends_folders(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_ADDITIONAL_JOBS_FOLDERS, "/extra/a:/extra/b")
@@ -71,7 +71,7 @@ class TestGetJobFolders:
         # Defaults should still be present
         assert tmp_path / ".deepwork" / "jobs" in folders
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.1.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_env_var_empty_is_ignored(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -81,7 +81,7 @@ class TestGetJobFolders:
         # Should only have the two defaults
         assert len(folders) == 2
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.1.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_env_var_strips_whitespace(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -95,7 +95,7 @@ class TestGetJobFolders:
 class TestLoadAllJobs:
     """Tests for load_all_jobs."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.2.1, REQ-008.2.4, REQ-008.2.7, REQ-008.2.8, REQ-008.2.11).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.2.1, JOBS-REQ-008.2.4, JOBS-REQ-008.2.7, JOBS-REQ-008.2.8, JOBS-REQ-008.2.11).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_loads_from_project_jobs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         jobs_dir = tmp_path / ".deepwork" / "jobs"
@@ -109,7 +109,7 @@ class TestLoadAllJobs:
         assert jobs[0].name == "my_job"
         assert len(errors) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.2.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.2.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_loads_from_multiple_folders(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -127,7 +127,7 @@ class TestLoadAllJobs:
         assert names == {"job_a", "job_b"}
         assert len(errors) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.2.5, REQ-008.2.6, REQ-008.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.2.5, JOBS-REQ-008.2.6, JOBS-REQ-008.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_first_folder_wins_for_duplicate_name(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -150,7 +150,7 @@ class TestLoadAllJobs:
         assert len(jobs) == 1
         assert jobs[0].summary == "Test job same_name"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_skips_nonexistent_folders(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -163,7 +163,7 @@ class TestLoadAllJobs:
         assert len(jobs) == 0
         assert len(errors) == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.2.9, REQ-008.2.11, REQ-008.5.1, REQ-008.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.2.9, JOBS-REQ-008.2.11, JOBS-REQ-008.5.1, JOBS-REQ-008.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_skips_invalid_jobs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         folder = tmp_path / "jobs"
@@ -185,7 +185,7 @@ class TestLoadAllJobs:
 class TestFindJobDir:
     """Tests for find_job_dir."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.1, REQ-008.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.3.1, JOBS-REQ-008.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_in_first_folder(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         folder = tmp_path / "jobs"
@@ -197,7 +197,7 @@ class TestFindJobDir:
         result = find_job_dir(tmp_path, "target")
         assert result == folder / "target"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.1, REQ-008.3.2, REQ-008.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.3.1, JOBS-REQ-008.3.2, JOBS-REQ-008.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_in_second_folder(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         folder_a = tmp_path / "a"
@@ -211,7 +211,7 @@ class TestFindJobDir:
         result = find_job_dir(tmp_path, "target")
         assert result == folder_b / "target"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_none_when_not_found(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -223,7 +223,7 @@ class TestFindJobDir:
         result = find_job_dir(tmp_path, "nonexistent")
         assert result is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.1, REQ-008.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-008.3.1, JOBS-REQ-008.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_prefers_first_folder_on_duplicate(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/jobs/test_parser.py
+++ b/tests/unit/jobs/test_parser.py
@@ -18,7 +18,7 @@ from deepwork.jobs.parser import (
 class TestStepInput:
     """Tests for StepInput dataclass."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_user_input(self) -> None:
         """Test user parameter input."""
@@ -27,7 +27,7 @@ class TestStepInput:
         assert inp.is_user_input()
         assert not inp.is_file_input()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_file_input(self) -> None:
         """Test file input from previous step."""
@@ -36,7 +36,7 @@ class TestStepInput:
         assert inp.is_file_input()
         assert not inp.is_user_input()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.2, REQ-002.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.2, JOBS-REQ-002.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_user_input(self) -> None:
         """Test creating user input from dictionary."""
@@ -47,7 +47,7 @@ class TestStepInput:
         assert inp.description == "First parameter"
         assert inp.is_user_input()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.3, REQ-002.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.3, JOBS-REQ-002.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_file_input(self) -> None:
         """Test creating file input from dictionary."""
@@ -62,7 +62,7 @@ class TestStepInput:
 class TestOutputSpec:
     """Tests for OutputSpec dataclass."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.1, REQ-002.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.1, JOBS-REQ-002.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_file_output(self) -> None:
         """Test single file output."""
@@ -75,7 +75,7 @@ class TestOutputSpec:
         assert output.description == "An output file"
         assert output.required is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.1, REQ-002.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.1, JOBS-REQ-002.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_files_output(self) -> None:
         """Test multiple files output."""
@@ -91,7 +91,7 @@ class TestOutputSpec:
         assert output.description == "Instruction files"
         assert output.required is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_optional_output(self) -> None:
         """Test optional output with required=False."""
@@ -100,7 +100,7 @@ class TestOutputSpec:
         assert output.name == "bonus.md"
         assert output.required is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.1, REQ-002.5.2, REQ-002.5.3, REQ-002.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.1, JOBS-REQ-002.5.2, JOBS-REQ-002.5.3, JOBS-REQ-002.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict(self) -> None:
         """Test creating output from name and dict."""
@@ -112,7 +112,7 @@ class TestOutputSpec:
         assert output.description == "An output file"
         assert output.required is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_files_type(self) -> None:
         """Test creating files-type output from dict."""
@@ -124,7 +124,7 @@ class TestOutputSpec:
         assert output.description == "Multiple output files"
         assert output.required is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_optional(self) -> None:
         """Test creating optional output from dict."""
@@ -138,7 +138,7 @@ class TestOutputSpec:
 class TestReview:
     """Tests for Review dataclass."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.7.1, REQ-002.7.2, REQ-002.7.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.7.1, JOBS-REQ-002.7.2, JOBS-REQ-002.7.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict(self) -> None:
         """Test creating review from dictionary."""
@@ -151,7 +151,7 @@ class TestReview:
         assert review.run_each == "step"
         assert review.quality_criteria == {"Complete": "Is it complete?", "Valid": "Is it valid?"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_output_specific(self) -> None:
         """Test creating review targeting specific output."""
@@ -175,7 +175,7 @@ class TestReview:
 class TestStep:
     """Tests for Step dataclass."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.1, REQ-002.3.3, REQ-002.3.4, REQ-002.3.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.3.1, JOBS-REQ-002.3.3, JOBS-REQ-002.3.4, JOBS-REQ-002.3.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_minimal(self) -> None:
         """Test creating step from minimal dictionary."""
@@ -200,7 +200,7 @@ class TestStep:
         assert step.inputs == []
         assert step.dependencies == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_with_multiple_outputs(self) -> None:
         """Test creating step with file and files type outputs."""
@@ -230,7 +230,7 @@ class TestStep:
         attachments = next(out for out in step.outputs if out.name == "attachments")
         assert attachments.type == "files"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.1, REQ-002.4.4, REQ-002.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.1, JOBS-REQ-002.4.4, JOBS-REQ-002.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_with_inputs(self) -> None:
         """Test creating step with inputs."""
@@ -255,7 +255,7 @@ class TestStep:
         assert step.inputs[1].is_file_input()
         assert step.dependencies == ["step0"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.3.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_exposed_default_false(self) -> None:
         """Test that exposed defaults to False."""
@@ -272,7 +272,7 @@ class TestStep:
 
         assert step.exposed is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_exposed_true(self) -> None:
         """Test creating step with exposed=True."""
@@ -290,7 +290,7 @@ class TestStep:
 
         assert step.exposed is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.7.1, REQ-002.7.2, REQ-002.7.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.7.1, JOBS-REQ-002.7.2, JOBS-REQ-002.7.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_with_reviews(self) -> None:
         """Test creating step with reviews."""
@@ -320,7 +320,7 @@ class TestStep:
         assert step.reviews[0].quality_criteria == {"Complete": "Is it complete?"}
         assert step.reviews[1].run_each == "output.md"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.3.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_dict_empty_reviews(self) -> None:
         """Test creating step with empty reviews list."""
@@ -342,7 +342,7 @@ class TestStep:
 class TestJobDefinition:
     """Tests for JobDefinition dataclass."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.14.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.14.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_get_step(self, fixtures_dir: Path) -> None:
         """Test getting step by ID."""
@@ -355,7 +355,7 @@ class TestJobDefinition:
 
         assert job.get_step("nonexistent") is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_dependencies_valid(self, fixtures_dir: Path) -> None:
         """Test validation passes for valid dependencies."""
@@ -365,7 +365,7 @@ class TestJobDefinition:
         # Should not raise
         job.validate_dependencies()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_dependencies_missing_step(self) -> None:
         """Test validation fails for missing dependency."""
@@ -394,7 +394,7 @@ class TestJobDefinition:
         with pytest.raises(ParseError, match="depends on non-existent step"):
             job.validate_dependencies()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_dependencies_circular(self) -> None:
         """Test validation fails for circular dependencies."""
@@ -435,7 +435,7 @@ class TestJobDefinition:
         with pytest.raises(ParseError, match="Circular dependency detected"):
             job.validate_dependencies()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.10.1, REQ-002.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.10.1, JOBS-REQ-002.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_file_inputs_valid(self, fixtures_dir: Path) -> None:
         """Test file input validation passes for valid inputs."""
@@ -445,7 +445,7 @@ class TestJobDefinition:
         # Should not raise
         job.validate_file_inputs()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_file_inputs_missing_step(self) -> None:
         """Test file input validation fails for missing from_step."""
@@ -475,7 +475,7 @@ class TestJobDefinition:
         with pytest.raises(ParseError, match="references non-existent step"):
             job.validate_file_inputs()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.11.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.11.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_reviews_valid(self) -> None:
         """Test that validate_reviews passes for valid run_each values."""
@@ -507,7 +507,7 @@ class TestJobDefinition:
         # Should not raise
         job.validate_reviews()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.11.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.11.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_reviews_invalid_run_each(self) -> None:
         """Test that validate_reviews fails for invalid run_each."""
@@ -541,7 +541,7 @@ class TestJobDefinition:
         with pytest.raises(ParseError, match="run_each='nonexistent_output'"):
             job.validate_reviews()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validate_file_inputs_not_in_dependencies(self) -> None:
         """Test file input validation fails if from_step not in dependencies."""
@@ -587,7 +587,7 @@ class TestJobDefinition:
 class TestParseJobDefinition:
     """Tests for parse_job_definition function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.1, REQ-002.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.1, JOBS-REQ-002.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_simple_job(self, fixtures_dir: Path) -> None:
         """Test parsing simple job definition."""
@@ -601,7 +601,7 @@ class TestParseJobDefinition:
         assert job.steps[0].id == "single_step"
         assert job.job_dir == job_dir
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.2.8, REQ-002.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.2.8, JOBS-REQ-002.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_complex_job(self, fixtures_dir: Path) -> None:
         """Test parsing complex job with dependencies."""
@@ -623,7 +623,7 @@ class TestParseJobDefinition:
         assert "primary_research" in job.steps[3].dependencies
         assert "secondary_research" in job.steps[3].dependencies
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.1, REQ-002.4.2, REQ-002.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.1, JOBS-REQ-002.4.2, JOBS-REQ-002.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_user_inputs(self, fixtures_dir: Path) -> None:
         """Test parsing step with user inputs."""
@@ -635,7 +635,7 @@ class TestParseJobDefinition:
         assert step.inputs[0].is_user_input()
         assert step.inputs[0].name == "input_param"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.4.3, REQ-002.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.4.3, JOBS-REQ-002.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_file_inputs(self, fixtures_dir: Path) -> None:
         """Test parsing step with file inputs."""
@@ -648,7 +648,7 @@ class TestParseJobDefinition:
         assert step.inputs[0].file == "competitors.md"
         assert step.inputs[0].from_step == "identify_competitors"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.6, REQ-002.3.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.3.6, JOBS-REQ-002.3.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_exposed_steps(self, fixtures_dir: Path) -> None:
         """Test parsing job with exposed and hidden steps."""
@@ -663,7 +663,7 @@ class TestParseJobDefinition:
         assert job.steps[1].id == "exposed_step"
         assert job.steps[1].exposed is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_directory(self, temp_dir: Path) -> None:
         """Test parsing fails for missing directory."""
@@ -672,7 +672,7 @@ class TestParseJobDefinition:
         with pytest.raises(ParseError, match="does not exist"):
             parse_job_definition(nonexistent)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_file_instead_of_directory(self, temp_dir: Path) -> None:
         """Test parsing fails for file path."""
@@ -682,7 +682,7 @@ class TestParseJobDefinition:
         with pytest.raises(ParseError, match="not a directory"):
             parse_job_definition(file_path)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_job_yml(self, temp_dir: Path) -> None:
         """Test parsing fails for directory without job.yml."""
@@ -692,7 +692,7 @@ class TestParseJobDefinition:
         with pytest.raises(ParseError, match="job.yml not found"):
             parse_job_definition(job_dir)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_empty_job_yml(self, temp_dir: Path) -> None:
         """Test parsing fails for empty job.yml."""
@@ -703,7 +703,7 @@ class TestParseJobDefinition:
         with pytest.raises(ParseError, match="validation failed"):
             parse_job_definition(job_dir)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_invalid_yaml(self, temp_dir: Path) -> None:
         """Test parsing fails for invalid YAML."""
@@ -714,7 +714,7 @@ class TestParseJobDefinition:
         with pytest.raises(ParseError, match="Failed to load"):
             parse_job_definition(job_dir)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_invalid_schema(self, fixtures_dir: Path) -> None:
         """Test parsing fails for schema validation errors."""
@@ -727,7 +727,7 @@ class TestParseJobDefinition:
 class TestConcurrentSteps:
     """Tests for concurrent step parsing in workflows."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.8.1, REQ-002.8.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.8.1, JOBS-REQ-002.8.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_concurrent_steps_workflow(self, fixtures_dir: Path) -> None:
         """Test parsing job with concurrent steps in workflow."""
@@ -738,7 +738,7 @@ class TestConcurrentSteps:
         assert len(job.workflows) == 1
         assert job.workflows[0].name == "full_analysis"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.8.5, REQ-002.8.6, REQ-002.8.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.8.5, JOBS-REQ-002.8.6, JOBS-REQ-002.8.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_workflow_step_entries(self, fixtures_dir: Path) -> None:
         """Test workflow step_entries structure with concurrent steps."""
@@ -803,7 +803,7 @@ class TestConcurrentSteps:
         assert entry.is_concurrent
         assert "research_web" in entry.step_ids
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.14.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.14.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_get_step_entry_position_in_workflow(self, fixtures_dir: Path) -> None:
         """Test getting entry-based position in workflow."""
@@ -827,7 +827,7 @@ class TestConcurrentSteps:
             assert total_entries == 4
             assert entry.is_concurrent
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.14.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-002.14.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_get_concurrent_step_info(self, fixtures_dir: Path) -> None:
         """Test getting info about position within concurrent group."""

--- a/tests/unit/review/test_config.py
+++ b/tests/unit/review/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for deepreview configuration parsing (deepwork.review.config) — validates REQ-001."""
+"""Tests for deepreview configuration parsing (deepwork.review.config) — validates REVIEW-REQ-001."""
 
 from pathlib import Path
 
@@ -17,7 +17,7 @@ def _write_deepreview(path: Path, content: str) -> Path:
 class TestParseDeepReviewFile:
     """Tests for parse_deepreview_file."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.1.1, REQ-001.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.1.1, REVIEW-REQ-001.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_valid_yaml_with_single_rule(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -40,7 +40,7 @@ python_review:
         assert rules[0].strategy == "individual"
         assert rules[0].instructions == "Review this Python file."
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_multiple_rules(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -67,7 +67,7 @@ rule_b:
         names = {r.name for r in rules}
         assert names == {"rule_a", "rule_b"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_exclude_patterns(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -86,7 +86,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].exclude_patterns == ["tests/**/*.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.8.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.8.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_exclude_defaults_to_empty(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -104,7 +104,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].exclude_patterns == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_all_strategies(self, tmp_path: Path) -> None:
         for strategy in ("individual", "matches_together", "all_changed_files"):
@@ -123,7 +123,7 @@ rule:
             rules = parse_deepreview_file(filepath)
             assert rules[0].strategy == strategy
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.1, REQ-001.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.4.1, REVIEW-REQ-001.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_inline_instructions(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -141,7 +141,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].instructions == "Check for bugs."
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.1, REQ-001.4.3, REQ-001.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.4.1, REVIEW-REQ-001.4.3, REVIEW-REQ-001.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_file_reference_instructions(self, tmp_path: Path) -> None:
         (tmp_path / "review_guide.md").write_text(
@@ -163,7 +163,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].instructions == "# Review Guide\nCheck everything."
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_file_reference_not_found_raises_error(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -182,7 +182,7 @@ my_rule:
         with pytest.raises(ConfigError, match="Instructions file not found"):
             parse_deepreview_file(filepath)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.5.1, REQ-001.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.5.1, REVIEW-REQ-001.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_agent_config(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -202,7 +202,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].agent == {"claude": "security-expert"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.8.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.8.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_agent_defaults_to_none(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -220,7 +220,7 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].agent is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.6.2, REQ-001.6.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.6.2, REVIEW-REQ-001.6.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_parses_additional_context(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -242,7 +242,7 @@ my_rule:
         assert rules[0].all_changed_filenames is True
         assert rules[0].unchanged_matching_files is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.8.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.8.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_additional_context_defaults_to_false(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -261,7 +261,7 @@ my_rule:
         assert rules[0].all_changed_filenames is False
         assert rules[0].unchanged_matching_files is False
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_source_dir_set_to_parent(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -279,14 +279,14 @@ my_rule:
         rules = parse_deepreview_file(filepath)
         assert rules[0].source_dir == tmp_path
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.7.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.7.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_invalid_yaml_raises_error(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(tmp_path, "invalid: [yaml")
         with pytest.raises(ConfigError, match="Failed to parse"):
             parse_deepreview_file(filepath)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.7.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.7.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_schema_validation_failure_raises_error(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(
@@ -314,7 +314,7 @@ my_rule:
         with pytest.raises(ConfigError, match="File not found"):
             parse_deepreview_file(filepath)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-001.8.4, REQ-001.8.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-001.8.4, REVIEW-REQ-001.8.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_source_file_is_set(self, tmp_path: Path) -> None:
         filepath = _write_deepreview(

--- a/tests/unit/review/test_discovery.py
+++ b/tests/unit/review/test_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for deepreview configuration discovery (deepwork.review.discovery) — validates REQ-002."""
+"""Tests for deepreview configuration discovery (deepwork.review.discovery) — validates REVIEW-REQ-002."""
 
 from pathlib import Path
 
@@ -27,7 +27,7 @@ my_rule:
 class TestFindDeepReviewFiles:
     """Tests for find_deepreview_files."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.1, REQ-002.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.1, REVIEW-REQ-002.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_file_in_root(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)
@@ -35,7 +35,7 @@ class TestFindDeepReviewFiles:
         assert len(files) == 1
         assert files[0] == tmp_path / ".deepreview"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_files_in_subdirectories(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)
@@ -44,7 +44,7 @@ class TestFindDeepReviewFiles:
         files = find_deepreview_files(tmp_path)
         assert len(files) == 3
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_deepest_first_ordering(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)
@@ -56,13 +56,13 @@ class TestFindDeepReviewFiles:
         assert files[1] == tmp_path / "src" / ".deepreview"
         assert files[2] == tmp_path / ".deepreview"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_empty_when_none_found(self, tmp_path: Path) -> None:
         files = find_deepreview_files(tmp_path)
         assert files == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_skips_git_directory(self, tmp_path: Path) -> None:
         git_dir = tmp_path / ".git"
@@ -71,7 +71,7 @@ class TestFindDeepReviewFiles:
         files = find_deepreview_files(tmp_path)
         assert files == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_skips_node_modules(self, tmp_path: Path) -> None:
         nm_dir = tmp_path / "node_modules"
@@ -86,7 +86,7 @@ class TestFindDeepReviewFiles:
 class TestLoadAllRules:
     """Tests for load_all_rules."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.1, REQ-002.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.3.1, REVIEW-REQ-002.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_loads_rules_from_single_file(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)
@@ -95,7 +95,7 @@ class TestLoadAllRules:
         assert rules[0].name == "my_rule"
         assert errors == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_rules_from_multiple_files_are_independent(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)
@@ -117,7 +117,7 @@ src_rule:
         assert names == {"my_rule", "src_rule"}
         assert errors == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_source_dir_set_correctly(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path / "src", VALID_CONFIG)
@@ -125,7 +125,7 @@ src_rule:
         assert len(rules) == 1
         assert rules[0].source_dir == tmp_path / "src"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-002.3.4, REQ-002.3.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-002.3.4, REVIEW-REQ-002.3.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_invalid_file_reports_error_without_blocking(self, tmp_path: Path) -> None:
         _write_deepreview(tmp_path, VALID_CONFIG)

--- a/tests/unit/review/test_formatter.py
+++ b/tests/unit/review/test_formatter.py
@@ -1,4 +1,4 @@
-"""Tests for output formatting (deepwork.review.formatter) — validates REQ-006."""
+"""Tests for output formatting (deepwork.review.formatter) — validates REVIEW-REQ-006."""
 
 from pathlib import Path
 
@@ -23,13 +23,13 @@ def _make_task(
 class TestFormatForClaude:
     """Tests for format_for_claude."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_tasks_returns_no_tasks_message(self, tmp_path: Path) -> None:
         result = format_for_claude([], tmp_path)
         assert "No review tasks" in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_output_starts_with_invoke_line(self, tmp_path: Path) -> None:
         task = _make_task()
@@ -39,7 +39,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert result.startswith("Invoke the following list of Tasks in parallel:")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3a).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_individual_task_name_includes_filename(self, tmp_path: Path) -> None:
         task = _make_task(rule_name="py_review", files=["src/app.py"])
@@ -47,7 +47,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert 'name: "py_review review of src/app.py"' in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3a).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_grouped_task_name_includes_file_count(self, tmp_path: Path) -> None:
         task = _make_task(rule_name="py_review", files=["a.py", "b.py", "c.py"])
@@ -55,7 +55,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert 'name: "py_review review of 3 files"' in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3b).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3b).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_default_subagent_type_when_no_agent(self, tmp_path: Path) -> None:
         task = _make_task(agent_name=None)
@@ -63,7 +63,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert "subagent_type: general-purpose" in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3b).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3b).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_custom_subagent_type(self, tmp_path: Path) -> None:
         task = _make_task(agent_name="security-expert")
@@ -71,7 +71,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert "subagent_type: security-expert" in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3c).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3c).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_description_field_present(self, tmp_path: Path) -> None:
         task = _make_task(rule_name="py_review")
@@ -79,7 +79,7 @@ class TestFormatForClaude:
         result = format_for_claude([(task, file_path)], tmp_path)
         assert "description: Review py_review" in result
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.3c, REQ-006.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3c, REVIEW-REQ-006.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_prompt_references_instruction_file(self, tmp_path: Path) -> None:
         task = _make_task()

--- a/tests/unit/review/test_instructions.py
+++ b/tests/unit/review/test_instructions.py
@@ -1,4 +1,4 @@
-"""Tests for review instruction file generation (deepwork.review.instructions) — validates REQ-005."""
+"""Tests for review instruction file generation (deepwork.review.instructions) — validates REVIEW-REQ-005."""
 
 from pathlib import Path
 
@@ -33,14 +33,14 @@ def _make_task(
 class TestBuildInstructionFile:
     """Tests for build_instruction_file."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_rule_name_in_header(self) -> None:
         task = _make_task(rule_name="python_review")
         content = build_instruction_file(task)
         assert "# Review: python_review" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_review_instructions(self) -> None:
         task = _make_task(instructions="Check for security issues.")
@@ -48,7 +48,7 @@ class TestBuildInstructionFile:
         assert "## Review Instructions" in content
         assert "Check for security issues." in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.1.4, REQ-005.2.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.1.4, REVIEW-REQ-005.2.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_files_to_review_with_at_prefix(self) -> None:
         task = _make_task(files=["src/app.py", "src/lib.py"])
@@ -57,7 +57,7 @@ class TestBuildInstructionFile:
         assert "- @src/app.py" in content
         assert "- @src/lib.py" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.1.6, REQ-005.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.1.6, REVIEW-REQ-005.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_unchanged_matching_files(self) -> None:
         task = _make_task(additional_files=["src/unchanged.py"])
@@ -65,7 +65,7 @@ class TestBuildInstructionFile:
         assert "## Unchanged Matching Files" in content
         assert "- @src/unchanged.py" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.1.7, REQ-005.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.1.7, REVIEW-REQ-005.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_all_changed_filenames_without_at_prefix(self) -> None:
         task = _make_task(all_changed_filenames=["src/app.py", "tests/test.py", "README.md"])
@@ -106,14 +106,14 @@ class TestBuildInstructionFile:
         content = build_instruction_file(task)
         assert "3 files" in content.split("\n")[0]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.6.1, REQ-005.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.6.1, REVIEW-REQ-005.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_includes_traceability_blurb(self) -> None:
         task = _make_task(source_location="src/.deepreview:5")
         content = build_instruction_file(task)
         assert "This review was requested by the policy at `src/.deepreview:5`." in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.6.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.6.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_traceability_preceded_by_horizontal_rule(self) -> None:
         task = _make_task(source_location="src/.deepreview:5")
@@ -124,7 +124,7 @@ class TestBuildInstructionFile:
         # The line two above should be the horizontal rule (blank line between)
         assert "---" in lines[trace_idx - 2]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.6.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.6.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_omits_traceability_when_source_location_empty(self) -> None:
         task = _make_task(source_location="")
@@ -141,7 +141,7 @@ class TestBuildInstructionFile:
 class TestWriteInstructionFiles:
     """Tests for write_instruction_files."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.3.1, REQ-005.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.3.1, REVIEW-REQ-005.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_instruction_files(self, tmp_path: Path) -> None:
         tasks = [_make_task(rule_name="rule_a"), _make_task(rule_name="rule_b")]
@@ -153,7 +153,7 @@ class TestWriteInstructionFiles:
             assert file_path.suffix == ".md"
             assert ".deepwork/tmp/review_instructions" in str(file_path)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_unique_filenames(self, tmp_path: Path) -> None:
         tasks = [_make_task() for _ in range(10)]
@@ -161,7 +161,7 @@ class TestWriteInstructionFiles:
         paths = [r[1] for r in results]
         assert len(set(paths)) == 10  # All unique
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_clears_previous_files(self, tmp_path: Path) -> None:
         instructions_dir = tmp_path / ".deepwork" / "tmp" / "review_instructions"
@@ -177,7 +177,7 @@ class TestWriteInstructionFiles:
         files = list(instructions_dir.iterdir())
         assert len(files) == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-005.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_task_path_tuples(self, tmp_path: Path) -> None:
         task = _make_task(rule_name="my_rule")

--- a/tests/unit/review/test_matcher.py
+++ b/tests/unit/review/test_matcher.py
@@ -1,4 +1,4 @@
-"""Tests for changed file detection and rule matching (deepwork.review.matcher) — validates REQ-003, REQ-004."""
+"""Tests for changed file detection and rule matching (deepwork.review.matcher) — validates REVIEW-REQ-003, REVIEW-REQ-004."""
 
 import inspect
 import os
@@ -95,14 +95,14 @@ class TestGlobMatch:
 class TestMatchRule:
     """Tests for match_rule."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.1, REQ-004.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.1.1, REVIEW-REQ-004.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_matches_include_pattern(self, tmp_path: Path) -> None:
         rule = _make_rule(include=["**/*.py"], source_dir=tmp_path)
         matched = match_rule(["src/app.py", "src/lib.ts"], rule, tmp_path)
         assert matched == ["src/app.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.6, REQ-004.1.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.1.6, REVIEW-REQ-004.1.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_exclude_pattern_filters_out(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -113,7 +113,7 @@ class TestMatchRule:
         matched = match_rule(["src/app.py", "tests/test_app.py"], rule, tmp_path)
         assert matched == ["src/app.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_file_outside_source_dir_not_matched(self, tmp_path: Path) -> None:
         source = tmp_path / "src"
@@ -131,7 +131,7 @@ class TestMatchRule:
 class TestMatchFilesToRules:
     """Tests for match_files_to_rules."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.3.1, REQ-004.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.3.1, REVIEW-REQ-004.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_individual_strategy_creates_one_task_per_file(self, tmp_path: Path) -> None:
         rule = _make_rule(strategy="individual", source_dir=tmp_path)
@@ -144,7 +144,7 @@ class TestMatchFilesToRules:
         assert tasks[0].files_to_review == ["app.py"]
         assert tasks[1].files_to_review == ["lib.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.4.1, REQ-004.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.4.1, REVIEW-REQ-004.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_matches_together_strategy_creates_single_task(self, tmp_path: Path) -> None:
         rule = _make_rule(strategy="matches_together", source_dir=tmp_path)
@@ -156,7 +156,7 @@ class TestMatchFilesToRules:
         assert len(tasks) == 1
         assert set(tasks[0].files_to_review) == {"app.py", "lib.py"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.1, REQ-004.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.5.1, REVIEW-REQ-004.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_all_changed_files_strategy_includes_all(self, tmp_path: Path) -> None:
         rule = _make_rule(strategy="all_changed_files", source_dir=tmp_path)
@@ -168,7 +168,7 @@ class TestMatchFilesToRules:
         assert len(tasks) == 1
         assert set(tasks[0].files_to_review) == {"app.py", "lib.py", "main.ts"}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_all_changed_files_not_triggered_without_match(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -183,7 +183,7 @@ class TestMatchFilesToRules:
         )
         assert tasks == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_no_match_produces_no_tasks(self, tmp_path: Path) -> None:
         rule = _make_rule(include=["**/*.py"], source_dir=tmp_path)
@@ -194,7 +194,7 @@ class TestMatchFilesToRules:
         )
         assert tasks == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.6.1, REQ-004.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.6.1, REVIEW-REQ-004.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_all_changed_filenames_context(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -207,7 +207,7 @@ class TestMatchFilesToRules:
         assert len(tasks) == 1  # Only app.py matches
         assert tasks[0].all_changed_filenames == ["app.py", "main.ts"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.8.2, REQ-004.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.8.2, REVIEW-REQ-004.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_agent_resolution(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -217,7 +217,7 @@ class TestMatchFilesToRules:
         tasks = match_files_to_rules(["app.py"], [rule], tmp_path, platform="claude")
         assert tasks[0].agent_name == "security-expert"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_agent_resolution_missing_platform(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -227,7 +227,7 @@ class TestMatchFilesToRules:
         tasks = match_files_to_rules(["app.py"], [rule], tmp_path, platform="claude")
         assert tasks[0].agent_name is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_source_location_set_on_tasks(self, tmp_path: Path) -> None:
         rule = _make_rule(
@@ -238,7 +238,7 @@ class TestMatchFilesToRules:
         tasks = match_files_to_rules(["app.py"], [rule], tmp_path)
         assert tasks[0].source_location == ".deepreview:3"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_multiple_rules_processed_independently(self, tmp_path: Path) -> None:
         rule_a = _make_rule(name="rule_a", include=["**/*.py"], source_dir=tmp_path)
@@ -248,7 +248,7 @@ class TestMatchFilesToRules:
         assert tasks[0].rule_name == "rule_a"
         assert tasks[1].rule_name == "rule_b"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-004.4.3, REQ-004.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-004.4.3, REVIEW-REQ-004.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_unchanged_matching_files(self, tmp_path: Path) -> None:
         # Create files on disk for the glob scan
@@ -273,13 +273,13 @@ class TestMatchFilesToRules:
 class TestGetChangedFiles:
     """Tests for get_changed_files."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_on_non_git_repo(self, tmp_path: Path) -> None:
         with pytest.raises(GitDiffError):
             get_changed_files(tmp_path)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.2, REQ-003.1.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.2, REVIEW-REQ-003.1.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -292,7 +292,7 @@ class TestGetChangedFiles:
         files = get_changed_files(tmp_path)
         assert files == ["a.py", "b.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._git_diff_name_only")
     @patch("deepwork.review.matcher._get_merge_base", return_value="abc123")
@@ -303,7 +303,7 @@ class TestGetChangedFiles:
         get_changed_files(tmp_path, base_ref="develop")
         mock_merge_base.assert_called_once_with(tmp_path, "develop")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._git_diff_name_only")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -318,7 +318,7 @@ class TestGetChangedFiles:
         # Paths should be relative (no leading /)
         assert all(not p.startswith("/") for p in result)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -337,7 +337,7 @@ class TestGetChangedFiles:
                     f"Expected --diff-filter=ACMR in git diff command: {cmd}"
                 )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
     @patch("deepwork.review.matcher._get_merge_base", return_value="abc123")
@@ -360,7 +360,7 @@ class TestGetChangedFiles:
         # Second call: staged changes (ref=None, staged=True)
         assert second_call == call(tmp_path, None, staged=True)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.1.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.1.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._git_diff_name_only")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -375,14 +375,14 @@ class TestGetChangedFiles:
             assert not Path(path).is_absolute(), f"Path should be relative: {path}"
             assert not path.startswith("/"), f"Path should not start with /: {path}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_base_ref_defaults_to_none(self) -> None:
         sig = inspect.signature(get_changed_files)
         base_ref_param = sig.parameters["base_ref"]
         assert base_ref_param.default is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._git_diff_name_only")
     @patch("deepwork.review.matcher._get_merge_base", return_value="abc123")
@@ -395,7 +395,7 @@ class TestGetChangedFiles:
         mock_detect.assert_called_once_with(tmp_path)
         mock_merge_base.assert_called_once_with(tmp_path, "main")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_detect_base_ref_prefers_main_over_master(self, mock_run: Any, tmp_path: Path) -> None:
@@ -409,7 +409,7 @@ class TestGetChangedFiles:
         first_call_cmd = mock_run.call_args_list[0][0][0]
         assert "main" in first_call_cmd
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_detect_base_ref_falls_back_to_master(self, mock_run: Any, tmp_path: Path) -> None:
@@ -426,7 +426,7 @@ class TestGetChangedFiles:
         result = _detect_base_ref(tmp_path)
         assert result == "master"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_detect_base_ref_falls_back_to_head(self, mock_run: Any, tmp_path: Path) -> None:
@@ -437,7 +437,7 @@ class TestGetChangedFiles:
         result = _detect_base_ref(tmp_path)
         assert result == "HEAD"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_uses_git_merge_base(self, mock_run: Any, tmp_path: Path) -> None:
@@ -452,7 +452,7 @@ class TestGetChangedFiles:
         assert "main" in cmd
         assert result == "deadbeef"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -469,7 +469,7 @@ class TestGetChangedFiles:
                 f"Expected cwd={tmp_path}, got cwd={kwargs.get('cwd')} for command {c}"
             )
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher._git_diff_name_only")
     @patch("deepwork.review.matcher._detect_base_ref", return_value="main")
@@ -483,7 +483,7 @@ class TestGetChangedFiles:
         cwd_after = os.getcwd()
         assert cwd_before == cwd_after
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_invalid_base_ref_raises_error(self, mock_run: Any, tmp_path: Path) -> None:
@@ -495,7 +495,7 @@ class TestGetChangedFiles:
         with pytest.raises(GitDiffError, match="nonexistent_branch"):
             _get_merge_base(tmp_path, "nonexistent_branch")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-003.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-003.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.review.matcher.subprocess.run")
     def test_stderr_included_in_error_message(self, mock_run: Any, tmp_path: Path) -> None:

--- a/tests/unit/review/test_mcp.py
+++ b/tests/unit/review/test_mcp.py
@@ -175,7 +175,7 @@ class TestReviewToolRegistration:
         assert "get_review_instructions" in server_default._tool_manager._tools
 
     def test_get_configured_reviews_tool_is_registered(self, tmp_path: Path) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.1.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         """get_configured_reviews is registered on the MCP server."""
         from deepwork.jobs.mcp.server import create_server
@@ -188,11 +188,11 @@ class TestReviewToolRegistration:
 
 
 class TestGetConfiguredReviews:
-    """Tests for the get_configured_reviews adapter function — validates REQ-008."""
+    """Tests for the get_configured_reviews adapter function — validates REVIEW-REQ-008."""
 
     @patch("deepwork.review.mcp.load_all_rules")
     def test_returns_all_rules(self, mock_load: Any, tmp_path: Path) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.3, REQ-008.2.1, REQ-008.2.2, REQ-008.2.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.1.3, REVIEW-REQ-008.2.1, REVIEW-REQ-008.2.2, REVIEW-REQ-008.2.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         rule1 = _make_rule(tmp_path)
         rule2 = ReviewRule(
@@ -221,7 +221,7 @@ class TestGetConfiguredReviews:
 
     @patch("deepwork.review.mcp.load_all_rules")
     def test_returns_empty_when_no_rules(self, mock_load: Any, tmp_path: Path) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.1.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.1.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         mock_load.return_value = ([], [])
         result = get_configured_reviews(tmp_path)
@@ -229,7 +229,7 @@ class TestGetConfiguredReviews:
 
     @patch("deepwork.review.mcp.load_all_rules")
     def test_filters_by_matching_files(self, mock_load: Any, tmp_path: Path) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.3.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         py_rule = _make_rule(tmp_path)  # includes **/*.py
         ts_rule = ReviewRule(
@@ -254,7 +254,7 @@ class TestGetConfiguredReviews:
 
     @patch("deepwork.review.mcp.load_all_rules")
     def test_no_filter_returns_all(self, mock_load: Any, tmp_path: Path) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.3.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.3.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         rule = _make_rule(tmp_path)
         mock_load.return_value = ([rule], [])
@@ -267,7 +267,7 @@ class TestGetConfiguredReviews:
     def test_discovery_errors_still_return_valid_rules(
         self, mock_load: Any, tmp_path: Path
     ) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-008.4.1, REQ-008.4.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-008.4.1, REVIEW-REQ-008.4.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         from deepwork.review.discovery import DiscoveryError
 

--- a/tests/unit/review/test_plugin_skills.py
+++ b/tests/unit/review/test_plugin_skills.py
@@ -1,4 +1,4 @@
-"""Tests for DeepWork Reviews plugin skills and documentation — validates REQ-007."""
+"""Tests for DeepWork Reviews plugin skills and documentation — validates REVIEW-REQ-007."""
 
 from pathlib import Path
 from typing import Any
@@ -21,168 +21,168 @@ def _parse_frontmatter(skill_path: Path) -> dict[str, Any]:
 
 
 class TestReviewSkill:
-    """Tests for the review skill (REQ-007.1)."""
+    """Tests for the review skill (REVIEW-REQ-007.1)."""
 
     skill_path = SKILLS_DIR / "review" / "SKILL.md"
 
     def test_skill_file_exists(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.1: review skill exists at expected path."""
+        """REVIEW-REQ-007.1.1: review skill exists at expected path."""
         assert self.skill_path.exists()
 
     def test_frontmatter_name(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.2: name field is 'review'."""
+        """REVIEW-REQ-007.1.2: name field is 'review'."""
         fm = _parse_frontmatter(self.skill_path)
         assert fm["name"] == "review"
 
     def test_frontmatter_description(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.3: description field is present."""
+        """REVIEW-REQ-007.1.3: description field is present."""
         fm = _parse_frontmatter(self.skill_path)
         assert "description" in fm
         assert len(fm["description"]) > 0
 
     def test_instructs_to_call_review_mcp_tool(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.4).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.4).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.4: skill tells agent to call the review MCP tool."""
+        """REVIEW-REQ-007.1.4: skill tells agent to call the review MCP tool."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "mcp__deepwork__get_review_instructions" in content
 
     def test_instructs_parallel_tasks(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.5).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.5).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.5: skill tells agent to launch tasks in parallel."""
+        """REVIEW-REQ-007.1.5: skill tells agent to launch tasks in parallel."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "parallel" in content.lower()
 
     def test_instructs_auto_apply_obvious_fixes(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.6).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.6).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.6: skill tells agent to auto-apply no-downside changes."""
+        """REVIEW-REQ-007.1.6: skill tells agent to auto-apply no-downside changes."""
         content = self.skill_path.read_text(encoding="utf-8")
         # Must mention making changes without asking for obvious fixes
         assert "without asking" in content.lower() or "immediately" in content.lower()
 
     def test_instructs_ask_user_for_tradeoffs(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.7).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.7).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.7: skill tells agent to use AskUserQuestion for trade-offs."""
+        """REVIEW-REQ-007.1.7: skill tells agent to use AskUserQuestion for trade-offs."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "AskUserQuestion" in content
 
     def test_instructs_iterate(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.8).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.8).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.8: skill tells agent to re-run after changes."""
+        """REVIEW-REQ-007.1.8: skill tells agent to re-run after changes."""
         content = self.skill_path.read_text(encoding="utf-8")
         # Must mention running again / repeating
         assert "again" in content.lower() or "repeat" in content.lower()
 
     def test_routes_config_to_configure_reviews(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.9).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.1.9).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.1.9: skill routes configuration requests to configure_reviews."""
+        """REVIEW-REQ-007.1.9: skill routes configuration requests to configure_reviews."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "configure_reviews" in content
 
 
 class TestConfigureReviewsSkill:
-    """Tests for the configure_reviews skill (REQ-007.2)."""
+    """Tests for the configure_reviews skill (REVIEW-REQ-007.2)."""
 
     skill_path = SKILLS_DIR / "configure_reviews" / "SKILL.md"
 
     def test_skill_file_exists(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.1: configure_reviews skill exists at expected path."""
+        """REVIEW-REQ-007.2.1: configure_reviews skill exists at expected path."""
         assert self.skill_path.exists()
 
     def test_frontmatter_name(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.2: name field is 'configure_reviews'."""
+        """REVIEW-REQ-007.2.2: name field is 'configure_reviews'."""
         fm = _parse_frontmatter(self.skill_path)
         assert fm["name"] == "configure_reviews"
 
     def test_frontmatter_description(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.3: description field is present."""
+        """REVIEW-REQ-007.2.3: description field is present."""
         fm = _parse_frontmatter(self.skill_path)
         assert "description" in fm
         assert len(fm["description"]) > 0
 
     def test_instructs_to_read_readme(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.4).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.4).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.4: skill tells agent to read README_REVIEWS.md."""
+        """REVIEW-REQ-007.2.4: skill tells agent to read README_REVIEWS.md."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "README_REVIEWS.md" in content
 
     def test_instructs_to_reuse_existing(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.5).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.5).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.5: skill tells agent to look at existing .deepreview files."""
+        """REVIEW-REQ-007.2.5: skill tells agent to look at existing .deepreview files."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert ".deepreview" in content
         assert "reuse" in content.lower() or "existing" in content.lower()
 
     def test_instructs_to_test_changes(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.6).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.2.6).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.2.6: skill tells agent to test by calling the review MCP tool."""
+        """REVIEW-REQ-007.2.6: skill tells agent to test by calling the review MCP tool."""
         content = self.skill_path.read_text(encoding="utf-8")
         assert "mcp__deepwork__get_review_instructions" in content
 
 
 class TestReferenceDocumentation:
-    """Tests for README_REVIEWS.md in the plugin (REQ-007.3)."""
+    """Tests for README_REVIEWS.md in the plugin (REVIEW-REQ-007.3)."""
 
     symlink_path = PLUGIN_DIR / "README_REVIEWS.md"
     root_readme = PROJECT_ROOT / "README_REVIEWS.md"
 
     def test_symlink_exists(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.1: README_REVIEWS.md exists in plugin directory."""
+        """REVIEW-REQ-007.3.1: README_REVIEWS.md exists in plugin directory."""
         assert self.symlink_path.exists()
 
     def test_is_symlink(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.2: plugin copy is a symlink."""
+        """REVIEW-REQ-007.3.2: plugin copy is a symlink."""
         assert self.symlink_path.is_symlink()
 
     def test_symlink_target(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.2: symlink points to ../../README_REVIEWS.md."""
+        """REVIEW-REQ-007.3.2: symlink points to ../../README_REVIEWS.md."""
         target = self.symlink_path.readlink()
         assert str(target) == "../../README_REVIEWS.md"
 
     def test_symlink_resolves(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.3: symlink target exists and is readable."""
+        """REVIEW-REQ-007.3.3: symlink target exists and is readable."""
         assert self.symlink_path.resolve().exists()
         content = self.symlink_path.read_text(encoding="utf-8")
         assert len(content) > 0
 
     def test_root_readme_exists(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.3: root README_REVIEWS.md exists."""
+        """REVIEW-REQ-007.3.3: root README_REVIEWS.md exists."""
         assert self.root_readme.exists()
 
     def test_documents_deepreview_format(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.4).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.4).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.4: documents .deepreview config format."""
+        """REVIEW-REQ-007.3.4: documents .deepreview config format."""
         content = self.root_readme.read_text(encoding="utf-8")
         assert ".deepreview" in content
         assert "strategy" in content
@@ -191,51 +191,51 @@ class TestReferenceDocumentation:
         assert "all_changed_files" in content
 
     def test_documents_instruction_variants(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.4).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.4).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.4: documents both inline and file reference instructions."""
+        """REVIEW-REQ-007.3.4: documents both inline and file reference instructions."""
         content = self.root_readme.read_text(encoding="utf-8")
         assert "instructions:" in content
         assert "file:" in content
 
     def test_documents_agent_personas(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.4).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.4).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.4: documents agent personas."""
+        """REVIEW-REQ-007.3.4: documents agent personas."""
         content = self.root_readme.read_text(encoding="utf-8")
         assert "agent:" in content
         assert "claude:" in content
 
     def test_recommends_deepwork_review_dir(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.5).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.3.5).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.3.5: recommends .deepwork/review/ for instruction files."""
+        """REVIEW-REQ-007.3.5: recommends .deepwork/review/ for instruction files."""
         content = self.root_readme.read_text(encoding="utf-8")
         assert ".deepwork/review/" in content
 
 
 class TestSkillDirectoryConventions:
-    """Tests for skill directory structure (REQ-007.4)."""
+    """Tests for skill directory structure (REVIEW-REQ-007.4)."""
 
     def test_each_skill_has_own_directory(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.1).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.4.1).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.4.1: each skill is in its own directory."""
+        """REVIEW-REQ-007.4.1: each skill is in its own directory."""
         skill_dirs = [d for d in SKILLS_DIR.iterdir() if d.is_dir()]
         assert len(skill_dirs) >= 3  # deepwork, review, configure_reviews
 
     def test_each_skill_has_skill_md(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.2).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.4.2).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.4.2: each skill directory contains SKILL.md."""
+        """REVIEW-REQ-007.4.2: each skill directory contains SKILL.md."""
         skill_dirs = [d for d in SKILLS_DIR.iterdir() if d.is_dir()]
         for skill_dir in skill_dirs:
             assert (skill_dir / "SKILL.md").exists(), f"{skill_dir.name} is missing SKILL.md"
 
     def test_name_matches_directory(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.3).
+        # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-007.4.3).
         # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-        """REQ-007.4.3: frontmatter name matches directory name."""
+        """REVIEW-REQ-007.4.3: frontmatter name matches directory name."""
         skill_dirs = [d for d in SKILLS_DIR.iterdir() if d.is_dir()]
         for skill_dir in skill_dirs:
             skill_file = skill_dir / "SKILL.md"

--- a/tests/unit/review/test_review_cli.py
+++ b/tests/unit/review/test_review_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the deepwork review CLI command (deepwork.cli.review) — validates REQ-006."""
+"""Tests for the deepwork review CLI command (deepwork.cli.review) — validates REVIEW-REQ-006."""
 
 from pathlib import Path
 from typing import Any
@@ -31,7 +31,7 @@ def _make_rule(tmp_path: Path) -> ReviewRule:
 class TestReviewCommand:
     """Tests for the review CLI command."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.load_all_rules")
     def test_no_config_files_found(self, mock_load: Any, tmp_path: Path) -> None:
@@ -44,7 +44,7 @@ class TestReviewCommand:
         assert result.exit_code == 0
         assert "No .deepreview configuration files found" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.get_changed_files")
     @patch("deepwork.cli.review.load_all_rules")
@@ -59,7 +59,7 @@ class TestReviewCommand:
         assert result.exit_code == 0
         assert "No changed files detected" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.match_files_to_rules")
     @patch("deepwork.cli.review.get_changed_files")
@@ -78,7 +78,7 @@ class TestReviewCommand:
         assert result.exit_code == 0
         assert "No review rules matched" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.get_changed_files")
     @patch("deepwork.cli.review.load_all_rules")
@@ -96,7 +96,7 @@ class TestReviewCommand:
         )
         assert result.exit_code == 1
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.load_all_rules")
     def test_discovery_errors_reported_but_continues(self, mock_load: Any, tmp_path: Path) -> None:
@@ -115,7 +115,7 @@ class TestReviewCommand:
         assert result.exit_code == 0
         assert "No .deepreview configuration files found" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.1, REQ-006.3.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.2.1, REVIEW-REQ-006.3.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.format_for_claude")
     @patch("deepwork.cli.review.write_instruction_files")
@@ -153,7 +153,7 @@ class TestReviewCommand:
         assert "Invoke the following" in result.output
         mock_format.assert_called_once()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_instructions_for_is_required(self) -> None:
         runner = CliRunner()
@@ -161,7 +161,7 @@ class TestReviewCommand:
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.match_files_to_rules")
     @patch("deepwork.cli.review.get_changed_files")
@@ -193,7 +193,7 @@ class TestReviewCommand:
         called_files = mock_match.call_args[0][0]
         assert called_files == ["src/a.py", "src/b.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.match_files_to_rules")
     @patch("deepwork.cli.review.get_changed_files")
@@ -215,7 +215,7 @@ class TestReviewCommand:
         called_files = mock_match.call_args[0][0]
         assert called_files == ["src/x.py", "src/y.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.6.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.match_files_to_rules")
     @patch("deepwork.cli.review.get_changed_files")
@@ -245,7 +245,7 @@ class TestReviewCommand:
         called_files = mock_match.call_args[0][0]
         assert called_files == ["a.py", "z.py"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.5.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.write_instruction_files")
     @patch("deepwork.cli.review.match_files_to_rules")
@@ -274,7 +274,7 @@ class TestReviewCommand:
         assert result.exit_code == 1
         assert "Error writing instruction files" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.review.match_files_to_rules")
     @patch("deepwork.cli.review.get_changed_files")

--- a/tests/unit/test_create_agent_script.py
+++ b/tests/unit/test_create_agent_script.py
@@ -1,7 +1,7 @@
-"""Tests for create_agent.sh -- validates learning-agents REQ-002.
+"""Tests for create_agent.sh -- validates learning-agents LA-REQ-002.
 
 These tests validate the scaffold script behavior for agent creation,
-including template-based agent seeding (REQ-002.16 through REQ-002.22).
+including template-based agent seeding (LA-REQ-002.16 through LA-REQ-002.22).
 """
 
 import subprocess
@@ -53,15 +53,15 @@ def run_script(
 
 
 class TestBaselineCreation:
-    """Non-template agent creation (REQ-002.6, REQ-002.8, REQ-002.10, REQ-002.11)."""
+    """Non-template agent creation (LA-REQ-002.6, LA-REQ-002.8, LA-REQ-002.10, LA-REQ-002.11)."""
 
-    # REQ-002.11
+    # LA-REQ-002.11
     def test_no_args_exits_with_error(self, work_dir: Path) -> None:
         result = subprocess.run([str(SCRIPT_PATH)], cwd=work_dir, capture_output=True, text=True)
         assert result.returncode == 1
         assert "Usage:" in result.stderr
 
-    # REQ-002.6
+    # LA-REQ-002.6
     def test_creates_directory_structure(self, work_dir: Path) -> None:
         result = run_script(work_dir, "test-agent")
         assert result.returncode == 0
@@ -72,7 +72,7 @@ class TestBaselineCreation:
         assert (agent_dir / "learnings" / ".gitkeep").is_file()
         assert (agent_dir / "additional_learning_guidelines" / "README.md").is_file()
 
-    # REQ-002.6
+    # LA-REQ-002.6
     def test_creates_todo_placeholder_without_template(self, work_dir: Path) -> None:
         run_script(work_dir, "test-agent")
         content = (
@@ -80,7 +80,7 @@ class TestBaselineCreation:
         ).read_text()
         assert "TODO" in content
 
-    # REQ-002.8
+    # LA-REQ-002.8
     def test_creates_claude_agent_file(self, work_dir: Path) -> None:
         result = run_script(work_dir, "test-agent")
         assert result.returncode == 0
@@ -90,7 +90,7 @@ class TestBaselineCreation:
         content = agent_file.read_text()
         assert "name: TODO" in content
 
-    # REQ-002.10
+    # LA-REQ-002.10
     def test_idempotent_does_not_overwrite(self, work_dir: Path) -> None:
         run_script(work_dir, "test-agent")
         ck = work_dir / ".deepwork" / "learning-agents" / "test-agent" / "core-knowledge.md"
@@ -103,14 +103,14 @@ class TestBaselineCreation:
 
 
 class TestTemplateCreation:
-    """Template-based agent creation (REQ-002.16 through REQ-002.22)."""
+    """Template-based agent creation (LA-REQ-002.16 through LA-REQ-002.22)."""
 
-    # REQ-002.16
+    # LA-REQ-002.16
     def test_accepts_optional_template_argument(self, work_dir: Path, template_agent: Path) -> None:
         result = run_script(work_dir, "new-agent", str(template_agent))
         assert result.returncode == 0
 
-    # REQ-002.16
+    # LA-REQ-002.16
     def test_without_template_creates_todo(self, work_dir: Path) -> None:
         run_script(work_dir, "new-agent")
         content = (
@@ -118,13 +118,13 @@ class TestTemplateCreation:
         ).read_text()
         assert "TODO" in content
 
-    # REQ-002.17
+    # LA-REQ-002.17
     def test_nonexistent_template_directory_exits_1(self, work_dir: Path) -> None:
         result = run_script(work_dir, "new-agent", "/nonexistent/path")
         assert result.returncode == 1
         assert "/nonexistent/path" in result.stderr
 
-    # REQ-002.18
+    # LA-REQ-002.18
     def test_template_missing_core_knowledge_exits_1(self, work_dir: Path, tmp_path: Path) -> None:
         empty_template = tmp_path / "empty-template"
         empty_template.mkdir()
@@ -133,7 +133,7 @@ class TestTemplateCreation:
         assert result.returncode == 1
         assert "core-knowledge.md" in result.stderr
 
-    # REQ-002.19
+    # LA-REQ-002.19
     def test_copies_core_knowledge_from_template(
         self, work_dir: Path, template_agent: Path
     ) -> None:
@@ -144,14 +144,14 @@ class TestTemplateCreation:
         assert "TODO" not in content
         assert "template domain" in content
 
-    # REQ-002.20
+    # LA-REQ-002.20
     def test_copies_topics_from_template(self, work_dir: Path, template_agent: Path) -> None:
         run_script(work_dir, "new-agent", str(template_agent))
         topics_dir = work_dir / ".deepwork" / "learning-agents" / "new-agent" / "topics"
         topic_files = sorted(f.name for f in topics_dir.glob("*.md"))
         assert topic_files == ["topic-one.md", "topic-two.md"]
 
-    # REQ-002.20
+    # LA-REQ-002.20
     def test_no_template_topics_leaves_empty(self, work_dir: Path, tmp_path: Path) -> None:
         template = tmp_path / "no-topics"
         template.mkdir()
@@ -166,14 +166,14 @@ class TestTemplateCreation:
         )
         assert len(md_files) == 0
 
-    # REQ-002.21
+    # LA-REQ-002.21
     def test_copies_learnings_from_template(self, work_dir: Path, template_agent: Path) -> None:
         run_script(work_dir, "new-agent", str(template_agent))
         learnings_dir = work_dir / ".deepwork" / "learning-agents" / "new-agent" / "learnings"
         learning_files = [f.name for f in learnings_dir.glob("*.md")]
         assert "learning-one.md" in learning_files
 
-    # REQ-002.21
+    # LA-REQ-002.21
     def test_no_template_learnings_leaves_empty(self, work_dir: Path, tmp_path: Path) -> None:
         template = tmp_path / "no-learnings"
         template.mkdir()
@@ -188,14 +188,14 @@ class TestTemplateCreation:
         )
         assert len(md_files) == 0
 
-    # REQ-002.22
+    # LA-REQ-002.22
     def test_reports_copy_counts(self, work_dir: Path, template_agent: Path) -> None:
         result = run_script(work_dir, "new-agent", str(template_agent))
         assert "Copied core-knowledge.md from template" in result.stdout
         assert "2 topic(s)" in result.stdout
         assert "1 learning(s)" in result.stdout
 
-    # REQ-002.22
+    # LA-REQ-002.22
     def test_no_copies_no_count_messages(self, work_dir: Path, tmp_path: Path) -> None:
         template = tmp_path / "minimal"
         template.mkdir()

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -10,7 +10,7 @@ from deepwork.utils.fs import copy_dir, ensure_dir, find_files, safe_read, safe_
 class TestEnsureDir:
     """Tests for ensure_dir function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.2.1, REQ-010.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.2.1, DW-REQ-010.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_new_directory(self, temp_dir: Path) -> None:
         """Test that ensure_dir creates a new directory."""
@@ -23,7 +23,7 @@ class TestEnsureDir:
         assert new_dir.is_dir()
         assert result == new_dir
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.2.1, REQ-010.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.2.1, DW-REQ-010.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_nested_directories(self, temp_dir: Path) -> None:
         """Test that ensure_dir creates nested directories."""
@@ -36,7 +36,7 @@ class TestEnsureDir:
         assert nested_dir.is_dir()
         assert result == nested_dir
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.2.2, REQ-010.2.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.2.2, DW-REQ-010.2.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_handles_existing_directory(self, temp_dir: Path) -> None:
         """Test that ensure_dir works with existing directories."""
@@ -60,7 +60,7 @@ class TestEnsureDir:
 class TestSafeWrite:
     """Tests for safe_write function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.3.2, REQ-010.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.3.2, DW-REQ-010.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_writes_content_to_file(self, temp_dir: Path) -> None:
         """Test that safe_write writes content to a file."""
@@ -72,7 +72,7 @@ class TestSafeWrite:
         assert file_path.exists()
         assert file_path.read_text() == content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_parent_directories(self, temp_dir: Path) -> None:
         """Test that safe_write creates parent directories."""
@@ -84,7 +84,7 @@ class TestSafeWrite:
         assert file_path.exists()
         assert file_path.read_text() == content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.3.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.3.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_overwrites_existing_file(self, temp_dir: Path) -> None:
         """Test that safe_write overwrites existing files."""
@@ -107,7 +107,7 @@ class TestSafeWrite:
 class TestSafeRead:
     """Tests for safe_read function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_reads_existing_file(self, temp_dir: Path) -> None:
         """Test that safe_read reads content from existing file."""
@@ -119,7 +119,7 @@ class TestSafeRead:
 
         assert result == content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_none_for_missing_file(self, temp_dir: Path) -> None:
         """Test that safe_read returns None for missing files."""
@@ -139,7 +139,7 @@ class TestSafeRead:
 
         assert result == content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_reads_unicode_content(self, temp_dir: Path) -> None:
         """Test that safe_read handles unicode content."""
@@ -155,7 +155,7 @@ class TestSafeRead:
 class TestCopyDir:
     """Tests for copy_dir function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.5.1, REQ-010.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.5.1, DW-REQ-010.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_copies_directory(self, temp_dir: Path) -> None:
         """Test that copy_dir copies a directory."""
@@ -171,7 +171,7 @@ class TestCopyDir:
         assert (dst / "file1.txt").read_text() == "Content 1"
         assert (dst / "file2.txt").read_text() == "Content 2"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.5.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.5.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_copies_nested_directories(self, temp_dir: Path) -> None:
         """Test that copy_dir copies nested directories."""
@@ -186,7 +186,7 @@ class TestCopyDir:
 
         assert (dst / "nested" / "deep" / "file.txt").read_text() == "Nested content"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.5.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.5.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_ignores_patterns(self, temp_dir: Path) -> None:
         """Test that copy_dir ignores specified patterns."""
@@ -206,7 +206,7 @@ class TestCopyDir:
         assert not (dst / "ignore.log").exists()
         assert not (dst / "__pycache__").exists()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_source(self, temp_dir: Path) -> None:
         """Test that copy_dir raises FileNotFoundError for missing source."""
@@ -216,7 +216,7 @@ class TestCopyDir:
         with pytest.raises(FileNotFoundError, match="Source directory does not exist"):
             copy_dir(src, dst)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.5.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.5.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_non_directory_source(self, temp_dir: Path) -> None:
         """Test that copy_dir raises NotADirectoryError for file source."""
@@ -231,7 +231,7 @@ class TestCopyDir:
 class TestFindFiles:
     """Tests for find_files function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.6.1, REQ-010.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.6.1, DW-REQ-010.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_files_with_simple_pattern(self, temp_dir: Path) -> None:
         """Test that find_files finds files with simple pattern."""
@@ -245,7 +245,7 @@ class TestFindFiles:
         assert temp_dir / "file1.txt" in results
         assert temp_dir / "file2.txt" in results
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_finds_files_with_recursive_pattern(self, temp_dir: Path) -> None:
         """Test that find_files finds files recursively."""
@@ -261,7 +261,7 @@ class TestFindFiles:
 
         assert len(results) == 3
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_sorted_results(self, temp_dir: Path) -> None:
         """Test that find_files returns sorted results."""
@@ -283,7 +283,7 @@ class TestFindFiles:
 
         assert results == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.6.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.6.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_directory(self, temp_dir: Path) -> None:
         """Test that find_files raises FileNotFoundError for missing directory."""
@@ -292,7 +292,7 @@ class TestFindFiles:
         with pytest.raises(FileNotFoundError, match="Directory does not exist"):
             find_files(nonexistent, "*.txt")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.6.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.6.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_non_directory(self, temp_dir: Path) -> None:
         """Test that find_files raises NotADirectoryError for file path."""

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -20,13 +20,13 @@ from deepwork.utils.git import (
 class TestIsGitRepo:
     """Tests for is_git_repo function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.1.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_for_git_repo(self, mock_git_repo: Path) -> None:
         """Test that is_git_repo returns True for Git repository."""
         assert is_git_repo(mock_git_repo)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.1.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_for_subdirectory(self, mock_git_repo: Path) -> None:
         """Test that is_git_repo returns True for subdirectory in Git repo."""
@@ -35,7 +35,7 @@ class TestIsGitRepo:
 
         assert is_git_repo(subdir)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.1.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.1.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_false_for_non_git_directory(self, temp_dir: Path) -> None:
         """Test that is_git_repo returns False for non-Git directory."""
@@ -49,7 +49,7 @@ class TestIsGitRepo:
 class TestGetRepo:
     """Tests for get_repo function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.2.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_repo_object(self, mock_git_repo: Path) -> None:
         """Test that get_repo returns Repo object."""
@@ -58,7 +58,7 @@ class TestGetRepo:
         assert repo is not None
         assert Path(repo.working_tree_dir) == mock_git_repo
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.2.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_works_from_subdirectory(self, mock_git_repo: Path) -> None:
         """Test that get_repo works from subdirectory."""
@@ -69,7 +69,7 @@ class TestGetRepo:
 
         assert Path(repo.working_tree_dir) == mock_git_repo
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.3, REQ-007.5.1, REQ-007.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.2.3, DW-REQ-007.5.1, DW-REQ-007.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_non_git_directory(self, temp_dir: Path) -> None:
         """Test that get_repo raises GitError for non-Git directory."""
@@ -80,7 +80,7 @@ class TestGetRepo:
 class TestGetRepoRoot:
     """Tests for get_repo_root function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_repo_root(self, mock_git_repo: Path) -> None:
         """Test that get_repo_root returns repository root."""
@@ -88,7 +88,7 @@ class TestGetRepoRoot:
 
         assert root == mock_git_repo
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.2.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.2.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_root_from_subdirectory(self, mock_git_repo: Path) -> None:
         """Test that get_repo_root returns root from subdirectory."""
@@ -103,7 +103,7 @@ class TestGetRepoRoot:
 class TestGetCurrentBranch:
     """Tests for get_current_branch function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_current_branch(self, mock_git_repo: Path) -> None:
         """Test that get_current_branch returns current branch name."""
@@ -113,7 +113,7 @@ class TestGetCurrentBranch:
         assert isinstance(branch_name, str)
         assert len(branch_name) > 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.1, REQ-007.3.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.1, DW-REQ-007.3.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_correct_branch_after_switch(self, mock_git_repo: Path) -> None:
         """Test that get_current_branch returns correct branch after switch."""
@@ -127,7 +127,7 @@ class TestGetCurrentBranch:
 class TestBranchExists:
     """Tests for branch_exists function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_for_existing_branch(self, mock_git_repo: Path) -> None:
         """Test that branch_exists returns True for existing branch."""
@@ -135,13 +135,13 @@ class TestBranchExists:
 
         assert branch_exists(mock_git_repo, current_branch)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_false_for_nonexistent_branch(self, mock_git_repo: Path) -> None:
         """Test that branch_exists returns False for nonexistent branch."""
         assert not branch_exists(mock_git_repo, "nonexistent-branch")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.4, REQ-007.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.4, DW-REQ-007.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_after_creating_branch(self, mock_git_repo: Path) -> None:
         """Test that branch_exists returns True after creating branch."""
@@ -153,7 +153,7 @@ class TestBranchExists:
 class TestCreateBranch:
     """Tests for create_branch function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_new_branch(self, mock_git_repo: Path) -> None:
         """Test that create_branch creates a new branch."""
@@ -161,7 +161,7 @@ class TestCreateBranch:
 
         assert branch_exists(mock_git_repo, "feature-branch")
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_and_checks_out_branch(self, mock_git_repo: Path) -> None:
         """Test that create_branch can checkout new branch."""
@@ -169,7 +169,7 @@ class TestCreateBranch:
 
         assert get_current_branch(mock_git_repo) == "feature-branch"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_without_checkout(self, mock_git_repo: Path) -> None:
         """Test that create_branch can create without checkout."""
@@ -179,7 +179,7 @@ class TestCreateBranch:
         assert branch_exists(mock_git_repo, "feature-branch")
         assert get_current_branch(mock_git_repo) == original_branch
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.3.7, REQ-007.5.1, REQ-007.5.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.3.7, DW-REQ-007.5.1, DW-REQ-007.5.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_duplicate_branch(self, mock_git_repo: Path) -> None:
         """Test that create_branch raises for duplicate branch name."""
@@ -192,13 +192,13 @@ class TestCreateBranch:
 class TestHasUncommittedChanges:
     """Tests for has_uncommitted_changes function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_false_for_clean_repo(self, mock_git_repo: Path) -> None:
         """Test that has_uncommitted_changes returns False for clean repo."""
         assert not has_uncommitted_changes(mock_git_repo)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_for_modified_file(self, mock_git_repo: Path) -> None:
         """Test that has_uncommitted_changes returns True for modified file."""
@@ -207,7 +207,7 @@ class TestHasUncommittedChanges:
 
         assert has_uncommitted_changes(mock_git_repo)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_true_for_new_file(self, mock_git_repo: Path) -> None:
         """Test that has_uncommitted_changes returns True for new file."""
@@ -216,7 +216,7 @@ class TestHasUncommittedChanges:
 
         assert has_uncommitted_changes(mock_git_repo)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_false_after_commit(self, mock_git_repo: Path) -> None:
         """Test that has_uncommitted_changes returns False after commit."""
@@ -233,7 +233,7 @@ class TestHasUncommittedChanges:
 class TestGetUntrackedFiles:
     """Tests for get_untracked_files function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_empty_list_for_clean_repo(self, mock_git_repo: Path) -> None:
         """Test that get_untracked_files returns empty list for clean repo."""
@@ -241,7 +241,7 @@ class TestGetUntrackedFiles:
 
         assert untracked == []
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-007.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-007.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_untracked_files(self, mock_git_repo: Path) -> None:
         """Test that get_untracked_files returns untracked files."""

--- a/tests/unit/test_hook_wrapper.py
+++ b/tests/unit/test_hook_wrapper.py
@@ -42,7 +42,7 @@ from deepwork.hooks.wrapper import (
 class TestHookInput:
     """Tests for HookInput normalization."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.3, REQ-006.4.1, REQ-006.4.2, REQ-006.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.3, DW-REQ-006.4.1, DW-REQ-006.4.2, DW-REQ-006.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_claude_stop_event(self) -> None:
         """Test normalizing Claude Stop event."""
@@ -64,7 +64,7 @@ class TestHookInput:
         assert hook_input.cwd == "/project"
         assert hook_input.raw_input == raw_data
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.10, REQ-006.4.1, REQ-006.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.10, DW-REQ-006.4.1, DW-REQ-006.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_gemini_after_agent_event(self) -> None:
         """Test normalizing Gemini AfterAgent event."""
@@ -82,7 +82,7 @@ class TestHookInput:
         assert hook_input.event == NormalizedEvent.AFTER_AGENT
         assert hook_input.session_id == "sess456"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.5, REQ-006.3.2, REQ-006.4.2, REQ-006.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.5, DW-REQ-006.3.2, DW-REQ-006.4.2, DW-REQ-006.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_claude_pretooluse_event(self) -> None:
         """Test normalizing Claude PreToolUse event."""
@@ -102,7 +102,7 @@ class TestHookInput:
         assert hook_input.tool_name == "write_file"
         assert hook_input.tool_input["file_path"] == "/path/to/file.txt"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.11, REQ-006.3.11, REQ-006.4.2, REQ-006.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.11, DW-REQ-006.3.11, DW-REQ-006.4.2, DW-REQ-006.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_from_gemini_beforetool_event(self) -> None:
         """Test normalizing Gemini BeforeTool event."""
@@ -121,7 +121,7 @@ class TestHookInput:
         assert hook_input.event == NormalizedEvent.BEFORE_TOOL
         assert hook_input.tool_name == "write_file"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.1, REQ-006.3.2, REQ-006.3.3, REQ-006.3.4, REQ-006.3.5, REQ-006.3.6, REQ-006.3.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.3.1, DW-REQ-006.3.2, DW-REQ-006.3.3, DW-REQ-006.3.4, DW-REQ-006.3.5, DW-REQ-006.3.6, DW-REQ-006.3.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_tool_name_normalization_claude(self) -> None:
         """Test Claude tool names are normalized to snake_case."""
@@ -142,7 +142,7 @@ class TestHookInput:
             hook_input = HookInput.from_dict(raw_data, Platform.CLAUDE)
             assert hook_input.tool_name == expected, f"Expected {expected} for {claude_name}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.3, REQ-006.2.4, REQ-006.2.5, REQ-006.2.6, REQ-006.2.7, REQ-006.2.8, REQ-006.2.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.3, DW-REQ-006.2.4, DW-REQ-006.2.5, DW-REQ-006.2.6, DW-REQ-006.2.7, DW-REQ-006.2.8, DW-REQ-006.2.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_event_normalization_claude(self) -> None:
         """Test all Claude events are normalized correctly."""
@@ -161,7 +161,7 @@ class TestHookInput:
             hook_input = HookInput.from_dict(raw_data, Platform.CLAUDE)
             assert hook_input.event == expected, f"Expected {expected} for {claude_event}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.10, REQ-006.2.11, REQ-006.2.12, REQ-006.2.13, REQ-006.2.14, REQ-006.2.15, REQ-006.2.16, REQ-006.2.17).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.10, DW-REQ-006.2.11, DW-REQ-006.2.12, DW-REQ-006.2.13, DW-REQ-006.2.14, DW-REQ-006.2.15, DW-REQ-006.2.16, DW-REQ-006.2.17).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_event_normalization_gemini(self) -> None:
         """Test all Gemini events are normalized correctly."""
@@ -181,7 +181,7 @@ class TestHookInput:
             hook_input = HookInput.from_dict(raw_data, Platform.GEMINI)
             assert hook_input.event == expected, f"Expected {expected} for {gemini_event}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_input(self) -> None:
         """Test handling of empty input."""
@@ -205,7 +205,7 @@ class TestHookInput:
 class TestHookOutput:
     """Tests for HookOutput denormalization."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.2, REQ-006.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.2, DW-REQ-006.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_output_produces_empty_json(self) -> None:
         """Test that empty HookOutput produces empty dict.
@@ -217,7 +217,7 @@ class TestHookOutput:
 
         assert result == {}
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.4, REQ-006.5.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.4, DW-REQ-006.5.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_block_decision_claude(self) -> None:
         """Test blocking output for Claude.
@@ -231,7 +231,7 @@ class TestHookOutput:
         assert result["decision"] == "block"
         assert result["reason"] == "Must complete X first"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.3, REQ-006.5.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.3, DW-REQ-006.5.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_block_decision_gemini_converts_to_deny(self) -> None:
         """Test that 'block' is converted to 'deny' for Gemini.
@@ -262,7 +262,7 @@ class TestHookOutput:
 
         assert result["decision"] == "allow"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.6, REQ-006.5.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.6, DW-REQ-006.5.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_continue_false(self) -> None:
         """Test continue=false output."""
@@ -272,7 +272,7 @@ class TestHookOutput:
         assert result["continue"] is False
         assert result["stopReason"] == "Critical error"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_suppress_output(self) -> None:
         """Test suppressOutput flag."""
@@ -281,7 +281,7 @@ class TestHookOutput:
 
         assert result["suppressOutput"] is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_context_for_claude_session_start(self) -> None:
         """Test context handling for Claude SessionStart."""
@@ -292,7 +292,7 @@ class TestHookOutput:
         assert result["hookSpecificOutput"]["hookEventName"] == "SessionStart"
         assert result["hookSpecificOutput"]["additionalContext"] == "Additional context here"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.6.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_context_for_claude_other_events(self) -> None:
         """Test context handling for Claude non-SessionStart events."""
@@ -301,7 +301,7 @@ class TestHookOutput:
 
         assert result["systemMessage"] == "Warning message"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.6.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.6.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_context_for_gemini(self) -> None:
         """Test context handling for Gemini."""
@@ -311,7 +311,7 @@ class TestHookOutput:
         assert "hookSpecificOutput" in result
         assert result["hookSpecificOutput"]["additionalContext"] == "Additional context"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.7.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.7.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raw_output_merged(self) -> None:
         """Test that raw_output is merged into result."""
@@ -328,7 +328,7 @@ class TestHookOutput:
 class TestNormalizeInput:
     """Tests for the normalize_input function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_valid_json(self) -> None:
         """Test normalizing valid JSON input."""
@@ -338,7 +338,7 @@ class TestNormalizeInput:
         assert hook_input.event == NormalizedEvent.AFTER_AGENT
         assert hook_input.session_id == "123"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.4, REQ-006.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.4, DW-REQ-006.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_json(self) -> None:
         """Test normalizing empty JSON input."""
@@ -347,7 +347,7 @@ class TestNormalizeInput:
         assert hook_input.session_id == ""
         assert hook_input.event == NormalizedEvent.AFTER_AGENT  # Default
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_string(self) -> None:
         """Test normalizing empty string input."""
@@ -355,7 +355,7 @@ class TestNormalizeInput:
 
         assert hook_input.session_id == ""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_whitespace_only(self) -> None:
         """Test normalizing whitespace-only input."""
@@ -363,7 +363,7 @@ class TestNormalizeInput:
 
         assert hook_input.session_id == ""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_invalid_json(self) -> None:
         """Test normalizing invalid JSON input."""
@@ -383,7 +383,7 @@ class TestNormalizeInput:
 class TestDenormalizeOutput:
     """Tests for the denormalize_output function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_produces_valid_json(self) -> None:
         """Test that output is valid JSON.
@@ -397,7 +397,7 @@ class TestDenormalizeOutput:
         parsed = json.loads(json_str)
         assert parsed["decision"] == "block"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_empty_output_produces_empty_object(self) -> None:
         """Test that empty output produces '{}' (allow response).
@@ -413,7 +413,7 @@ class TestDenormalizeOutput:
 class TestEventMappings:
     """Tests for event name mappings."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.3, REQ-006.2.4, REQ-006.2.5, REQ-006.2.6, REQ-006.2.7, REQ-006.2.8, REQ-006.2.9).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.3, DW-REQ-006.2.4, DW-REQ-006.2.5, DW-REQ-006.2.6, DW-REQ-006.2.7, DW-REQ-006.2.8, DW-REQ-006.2.9).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_all_claude_events_have_normalized_mapping(self) -> None:
         """Test that all Claude events have normalized mappings."""
@@ -430,7 +430,7 @@ class TestEventMappings:
         for event in claude_events:
             assert event in EVENT_TO_NORMALIZED[Platform.CLAUDE], f"Missing mapping for {event}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.10, REQ-006.2.11, REQ-006.2.12, REQ-006.2.13, REQ-006.2.14, REQ-006.2.15, REQ-006.2.16, REQ-006.2.17).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.10, DW-REQ-006.2.11, DW-REQ-006.2.12, DW-REQ-006.2.13, DW-REQ-006.2.14, DW-REQ-006.2.15, DW-REQ-006.2.16, DW-REQ-006.2.17).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_all_gemini_events_have_normalized_mapping(self) -> None:
         """Test that all Gemini events have normalized mappings."""
@@ -448,7 +448,7 @@ class TestEventMappings:
         for event in gemini_events:
             assert event in EVENT_TO_NORMALIZED[Platform.GEMINI], f"Missing mapping for {event}"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.18).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.18).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_normalized_to_event_roundtrip_claude(self) -> None:
         """Test that Claude events can be normalized and denormalized."""
@@ -463,14 +463,14 @@ class TestEventMappings:
 class TestToolMappings:
     """Tests for tool name mappings."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.3.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_claude_tools_normalize_to_snake_case(self) -> None:
         """Test Claude tool names normalize to snake_case."""
         for _claude_tool, normalized in TOOL_TO_NORMALIZED[Platform.CLAUDE].items():
             assert "_" in normalized or normalized.islower(), f"{normalized} should be snake_case"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.3.11).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.3.11).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_gemini_tools_are_already_snake_case(self) -> None:
         """Test Gemini tool names are already snake_case."""
@@ -521,7 +521,7 @@ class TestToolMappings:
 class TestIntegration:
     """Integration tests for the full normalization flow."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.3, REQ-006.5.4, REQ-006.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.3, DW-REQ-006.5.4, DW-REQ-006.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_claude_stop_hook_flow(self) -> None:
         """Test complete flow for Claude Stop hook.
@@ -552,7 +552,7 @@ class TestIntegration:
         assert result["decision"] == "block"
         assert "Rule X" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.2.10, REQ-006.5.3, REQ-006.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.2.10, DW-REQ-006.5.3, DW-REQ-006.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_gemini_afteragent_hook_flow(self) -> None:
         """Test complete flow for Gemini AfterAgent hook.
@@ -585,7 +585,7 @@ class TestIntegration:
         assert result["decision"] == "deny"
         assert "Rule Y" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.5.3, REQ-006.5.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.5.3, DW-REQ-006.5.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_cross_platform_same_hook_logic(self) -> None:
         """Test that the same hook logic produces correct output for both platforms.
@@ -631,7 +631,7 @@ class TestHookErrorHandling:
     error information rather than causing a generic "non-blocking status code" error.
     """
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.9.1, REQ-006.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.9.1, DW-REQ-006.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_format_hook_error_basic(self) -> None:
         """Test that format_hook_error produces blocking JSON with error details."""
@@ -644,7 +644,7 @@ class TestHookErrorHandling:
         assert "Something went wrong" in result["reason"]
         assert "Traceback" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.9.1, REQ-006.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.9.1, DW-REQ-006.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_format_hook_error_with_context(self) -> None:
         """Test that format_hook_error includes context when provided."""
@@ -657,7 +657,7 @@ class TestHookErrorHandling:
         assert "RuntimeError" in result["reason"]
         assert "Test error" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_format_hook_error_includes_traceback(self) -> None:
         """Test that format_hook_error includes the full traceback."""
@@ -671,7 +671,7 @@ class TestHookErrorHandling:
         assert "KeyError" in result["reason"]
         assert "missing_key" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.9.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.9.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_output_hook_error_produces_json(self, capsys: object) -> None:
         """Test that output_hook_error writes valid JSON to stdout."""
@@ -686,7 +686,7 @@ class TestHookErrorHandling:
         assert "TypeError" in result["reason"]
         assert "test context" in result["reason"]
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-006.10.3, REQ-006.10.4, REQ-006.10.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-006.10.3, DW-REQ-006.10.4, DW-REQ-006.10.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_run_hook_catches_hook_function_errors(self, capsys: object) -> None:
         """Test that run_hook outputs JSON when hook function raises an exception."""

--- a/tests/unit/test_install_cli.py
+++ b/tests/unit/test_install_cli.py
@@ -1,7 +1,7 @@
-"""Tests for deprecated install/sync CLI commands -- validates REQ-005.4.
+"""Tests for deprecated install/sync CLI commands -- validates DW-REQ-005.4.
 
 SCHEDULED REMOVAL: June 1st, 2026; details in PR https://github.com/Unsupervisedcom/deepwork/pull/227
-Delete this entire file when REQ-005.4 and the install/sync commands are removed.
+Delete this entire file when DW-REQ-005.4 and the install/sync commands are removed.
 """
 
 import json
@@ -16,7 +16,7 @@ from deepwork.cli.main import cli
 class TestInstallCommandOutput:
     """Tests for the install command's deprecation message."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_install_prints_deprecation_message(self, tmp_path: str) -> None:
         """install must print a deprecation message with uninstall instructions."""
@@ -29,7 +29,7 @@ class TestInstallCommandOutput:
         assert "brew uninstall deepwork" in result.output
         assert "uv tool uninstall deepwork" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.8).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.8).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_sync_prints_deprecation_message(self, tmp_path: str) -> None:
         """sync must print the same deprecation message as install."""
@@ -41,7 +41,7 @@ class TestInstallCommandOutput:
         assert "brew uninstall deepwork" in result.output
         assert "uv tool uninstall deepwork" in result.output
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_install_and_sync_produce_identical_output(self, tmp_path: str) -> None:
         """Both commands must execute the same shared implementation."""
@@ -57,7 +57,7 @@ class TestInstallCommandOutput:
 class TestInstallHiddenFromHelp:
     """Tests that install and sync are hidden from CLI help."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_install_not_in_help(self) -> None:
         """install must not appear in --help output."""
@@ -78,7 +78,7 @@ class TestInstallHiddenFromHelp:
         command_names = [line.split()[0] for line in command_lines if line.strip()]
         assert "install" not in command_names
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_sync_not_in_help(self) -> None:
         """sync must not appear in --help output."""
@@ -99,7 +99,7 @@ class TestInstallHiddenFromHelp:
         command_names = [line.split()[0] for line in command_lines if line.strip()]
         assert "sync" not in command_names
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_install_still_invocable(self, tmp_path: str) -> None:
         """Hidden commands must still be invocable directly."""
@@ -109,7 +109,7 @@ class TestInstallHiddenFromHelp:
 
         assert result.exit_code == 0
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_sync_still_invocable(self, tmp_path: str) -> None:
         """Hidden commands must still be invocable directly."""
@@ -128,7 +128,7 @@ class TestPluginConfigCreation:
         """Read .claude/settings.json relative to CWD."""
         return json.loads(Path(".claude/settings.json").read_text())
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_settings_file_from_scratch(self, tmp_path: str) -> None:
         """install must create .claude/settings.json when it does not exist."""
@@ -141,7 +141,7 @@ class TestPluginConfigCreation:
         assert "extraKnownMarketplaces" in settings
         assert "enabledPlugins" in settings
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.5).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.5).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_marketplace_entry_is_correct(self, tmp_path: str) -> None:
         """extraKnownMarketplaces must contain deepwork-plugins with correct source."""
@@ -158,7 +158,7 @@ class TestPluginConfigCreation:
             }
         }
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_enabled_plugins_are_correct(self, tmp_path: str) -> None:
         """enabledPlugins must include both deepwork and learning-agents plugins."""
@@ -170,7 +170,7 @@ class TestPluginConfigCreation:
         assert settings["enabledPlugins"]["deepwork@deepwork-plugins"] is True
         assert settings["enabledPlugins"]["learning-agents@deepwork-plugins"] is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_merges_with_existing_settings(self, tmp_path: str) -> None:
         """install must preserve existing keys in settings.json."""
@@ -192,7 +192,7 @@ class TestPluginConfigCreation:
         assert "deepwork-plugins" in settings["extraKnownMarketplaces"]
         assert settings["enabledPlugins"]["deepwork@deepwork-plugins"] is True
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.7).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.7).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_handles_invalid_json_gracefully(self, tmp_path: str) -> None:
         """install must not crash if settings.json contains invalid JSON."""
@@ -208,7 +208,7 @@ class TestPluginConfigCreation:
         assert "extraKnownMarketplaces" in settings
         assert "enabledPlugins" in settings
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.4.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.4.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_claude_directory_if_missing(self, tmp_path: str) -> None:
         """install must create the .claude/ directory if it does not exist."""

--- a/tests/unit/test_serve_cli.py
+++ b/tests/unit/test_serve_cli.py
@@ -10,7 +10,7 @@ from deepwork.cli.serve import serve
 class TestServeExternalRunnerOption:
     """Tests for --external-runner CLI option on the serve command."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.serve._serve_mcp")
     def test_default_external_runner_is_none(self, mock_serve: MagicMock, tmp_path: str) -> None:
@@ -26,7 +26,7 @@ class TestServeExternalRunnerOption:
         call_args = mock_serve.call_args
         assert call_args[0][4] is None or call_args.kwargs.get("external_runner") is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     @patch("deepwork.cli.serve._serve_mcp")
     def test_external_runner_claude(self, mock_serve: MagicMock, tmp_path: str) -> None:
@@ -42,7 +42,7 @@ class TestServeExternalRunnerOption:
         call_args = mock_serve.call_args[0]
         assert call_args[4] == "claude"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_external_runner_invalid_choice(self, tmp_path: str) -> None:
         """Test that invalid --external-runner values are rejected."""
@@ -52,7 +52,7 @@ class TestServeExternalRunnerOption:
         assert result.exit_code != 0
         assert "Invalid value" in result.output or "invalid" in result.output.lower()
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-005.2.6).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.2.6).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_help_shows_external_runner(self) -> None:
         """Test that --help shows the --external-runner option."""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -9,7 +9,7 @@ from deepwork.utils.validation import ValidationError, validate_against_schema
 class TestValidateAgainstSchema:
     """Tests for validate_against_schema function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_simple_job(self) -> None:
         """Test that validate_against_schema accepts valid simple job."""
@@ -36,7 +36,7 @@ class TestValidateAgainstSchema:
         # Should not raise
         validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_job_with_user_inputs(self) -> None:
         """Test validation of job with user input parameters."""
@@ -66,7 +66,7 @@ class TestValidateAgainstSchema:
 
         validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_job_with_file_inputs(self) -> None:
         """Test validation of job with file inputs from previous steps."""
@@ -108,7 +108,7 @@ class TestValidateAgainstSchema:
 
         validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_required_field(self) -> None:
         """Test that validation fails for missing required fields."""
@@ -123,7 +123,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="'summary' is a required property"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_invalid_job_name(self) -> None:
         """Test that validation fails for invalid job name."""
@@ -149,7 +149,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="does not match"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_invalid_version(self) -> None:
         """Test that validation fails for invalid version format."""
@@ -175,7 +175,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="does not match"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_empty_steps(self) -> None:
         """Test that validation fails for empty steps array."""
@@ -190,7 +190,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="should be non-empty"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_step_missing_outputs(self) -> None:
         """Test that validation fails for step without outputs."""
@@ -213,7 +213,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="'outputs' is a required property"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_invalid_input_format(self) -> None:
         """Test that validation fails for invalid input format."""
@@ -245,7 +245,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_complex_job(self, fixtures_dir) -> None:
         """Test validation of complex job fixture."""
@@ -257,7 +257,7 @@ class TestValidateAgainstSchema:
         assert job_data is not None
         validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_step_missing_reviews(self) -> None:
         """Test that validation fails for step without reviews field."""
@@ -283,7 +283,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError, match="'reviews' is a required property"):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_job_with_reviews(self) -> None:
         """Test validation of job with reviews."""
@@ -322,7 +322,7 @@ class TestValidateAgainstSchema:
 
         validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_review_missing_run_each(self) -> None:
         """Test validation fails for review without run_each."""
@@ -353,7 +353,7 @@ class TestValidateAgainstSchema:
         with pytest.raises(ValidationError):
             validate_against_schema(job_data, JOB_SCHEMA)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.10.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.10.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_review_empty_criteria(self) -> None:
         """Test validation fails for review with empty quality_criteria."""

--- a/tests/unit/test_yaml_utils.py
+++ b/tests/unit/test_yaml_utils.py
@@ -10,7 +10,7 @@ from deepwork.utils.yaml_utils import YAMLError, load_yaml, save_yaml, validate_
 class TestLoadYAML:
     """Tests for load_yaml function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_loads_valid_yaml(self, temp_dir: Path) -> None:
         """Test that load_yaml loads valid YAML."""
@@ -28,7 +28,7 @@ description: "A test job"
         assert result["version"] == "1.0.0"
         assert result["description"] == "A test job"
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.7.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.7.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_loads_nested_yaml(self, temp_dir: Path) -> None:
         """Test that load_yaml loads nested YAML structures."""
@@ -50,7 +50,7 @@ job:
         assert result["job"]["name"] == "test_job"
         assert len(result["job"]["steps"]) == 2
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.7.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.7.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_none_for_missing_file(self, temp_dir: Path) -> None:
         """Test that load_yaml returns None for missing file."""
@@ -60,7 +60,7 @@ job:
 
         assert result is None
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.7.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.7.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_returns_empty_dict_for_empty_file(self, temp_dir: Path) -> None:
         """Test that load_yaml returns empty dict for empty file."""
@@ -84,7 +84,7 @@ invalid:
         with pytest.raises(YAMLError, match="Failed to parse YAML file"):
             load_yaml(yaml_file)
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.7.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.7.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_non_dict_yaml(self, temp_dir: Path) -> None:
         """Test that load_yaml raises YAMLError for non-dictionary YAML."""
@@ -112,7 +112,7 @@ invalid:
 class TestSaveYAML:
     """Tests for save_yaml function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.8.1, REQ-010.8.3).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.8.1, DW-REQ-010.8.3).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_saves_simple_dict(self, temp_dir: Path) -> None:
         """Test that save_yaml saves simple dictionary."""
@@ -131,7 +131,7 @@ class TestSaveYAML:
         # PyYAML may or may not quote version strings
         assert "version: " in content and "1.0.0" in content
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.8.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.8.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_saves_nested_dict(self, temp_dir: Path) -> None:
         """Test that save_yaml saves nested dictionaries."""
@@ -153,7 +153,7 @@ class TestSaveYAML:
         loaded = load_yaml(yaml_file)
         assert loaded == data
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.8.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.8.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_creates_parent_directories(self, temp_dir: Path) -> None:
         """Test that save_yaml creates parent directories."""
@@ -177,7 +177,7 @@ class TestSaveYAML:
         assert loaded == new_data
         assert "old" not in (loaded or {})
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.8.4).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.8.4).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_preserves_order(self, temp_dir: Path) -> None:
         """Test that save_yaml preserves dictionary order."""
@@ -210,7 +210,7 @@ class TestSaveYAML:
 class TestValidateYAMLStructure:
     """Tests for validate_yaml_structure function."""
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.9.1).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.9.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_validates_required_keys_present(self) -> None:
         """Test that validate_yaml_structure passes when keys present."""
@@ -224,7 +224,7 @@ class TestValidateYAMLStructure:
         # Should not raise
         validate_yaml_structure(data, ["name", "version", "description"])
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.9.1, REQ-010.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.9.1, DW-REQ-010.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_missing_keys(self) -> None:
         """Test that validate_yaml_structure raises for missing keys."""
@@ -236,7 +236,7 @@ class TestValidateYAMLStructure:
         with pytest.raises(YAMLError, match="Missing required keys: description"):
             validate_yaml_structure(data, ["name", "version", "description"])
 
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REQ-010.9.2).
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-010.9.2).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_raises_for_multiple_missing_keys(self) -> None:
         """Test that validate_yaml_structure reports multiple missing keys."""


### PR DESCRIPTION
## Summary

- REQ numbers (001-010) were reused across 4 spec domains, making test→spec mapping ambiguous
- Added domain prefixes: `JOBS-REQ-`, `REVIEW-REQ-`, `LA-REQ-`, `DW-REQ-` to all 30 spec files, 26 test files, and the requirements-reviewer agent
- Every REQ reference is now globally unique — no inference from directory paths needed

## Test plan

- [ ] Verify `uv run pytest` passes (no test logic changed, only traceability comments)
- [ ] Spot-check a few test files to confirm prefixed REQ IDs match their spec domain
- [ ] Confirm no bare `REQ-0NN` references remain: `grep -rn "REQ-0[0-1][0-9]\." specs/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)