### PR TITLE
Add CLAUDE.md symlinks to ensure Claude Code reads project context

### DIFF
--- a/.deepreview
+++ b/.deepreview
@@ -470,6 +470,30 @@ job_schema_instruction_compatibility:
       - FAIL: Incompatibilities found. List each with the file path, line
         reference, the incompatible content, and what the schema actually says.
 
+agents_md_claude_md_symlink:
+  description: "Ensure every AGENTS.md file has a sibling CLAUDE.md symlink pointing to it, because Claude Code reads CLAUDE.md but ignores AGENTS.md."
+  match:
+    include:
+      - "**/AGENTS.md"
+  review:
+    strategy: individual
+    instructions: |
+      Claude Code reads CLAUDE.md for project context but does not read AGENTS.md.
+      Every AGENTS.md file MUST have a sibling CLAUDE.md that is a symlink pointing
+      to AGENTS.md, so that Claude Code picks up the same content.
+
+      Check whether a CLAUDE.md symlink exists in the same directory as the matched
+      AGENTS.md file. If it is missing or is not a symlink to AGENTS.md, create it:
+
+        ln -sf AGENTS.md <dir>/CLAUDE.md
+
+      The symlink target MUST be the relative path "AGENTS.md" (not an absolute path),
+      so the link remains valid after the directory is moved or cloned.
+
+      Output Format:
+      - PASS: CLAUDE.md symlink exists and points to AGENTS.md.
+      - FAIL: Symlink missing or incorrect — describe the current state and the fix applied.
+
 nix_claude_wrapper:
   description: "Ensure flake.nix always wraps the claude command with the required plugin dirs."
   match:

--- a/.deepwork/jobs/test_job_flow/CLAUDE.md
+++ b/.deepwork/jobs/test_job_flow/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.deepwork/jobs/update_job_schema/CLAUDE.md
+++ b/.deepwork/jobs/update_job_schema/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/doc/debugging_history/CLAUDE.md
+++ b/doc/debugging_history/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/deepwork/standard_jobs/deepwork_jobs/CLAUDE.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/deepwork/standard_jobs/deepwork_jobs/make_new_job.sh
+++ b/src/deepwork/standard_jobs/deepwork_jobs/make_new_job.sh
@@ -128,6 +128,10 @@ This folder and its subfolders are managed using `deepwork_jobs` workflows.
 2. **Direct edits** are fine for minor instruction tweaks
 EOF
 
+    # Create CLAUDE.md symlink pointing to AGENTS.md so Claude Code picks up the context
+    # (Claude Code reads CLAUDE.md but ignores AGENTS.md)
+    ln -s AGENTS.md "$job_path/CLAUDE.md"
+
     # Copy .deepreview template if available
     if [[ -f "$script_dir/template.deepreview" ]]; then
         cp "$script_dir/template.deepreview" "$job_path/.deepreview"
@@ -139,6 +143,7 @@ EOF
         echo "  ├── .deepreview"
     fi
     echo "  ├── AGENTS.md"
+    echo "  ├── CLAUDE.md -> AGENTS.md"
     echo "  ├── steps/"
     echo "  ├── hooks/.gitkeep"
     echo "  ├── scripts/.gitkeep"


### PR DESCRIPTION
## Summary
This PR ensures that Claude Code can properly read project context by creating CLAUDE.md symlinks that point to AGENTS.md files. Claude Code reads CLAUDE.md for project context but ignores AGENTS.md, so symlinks are necessary to bridge this gap.

## Key Changes
- **Added new deepreview job** (`agents_md_claude_md_symlink`): A validation rule that checks every AGENTS.md file has a corresponding CLAUDE.md symlink pointing to it, with instructions for creating missing symlinks
- **Updated job creation script** (`make_new_job.sh`): Automatically creates CLAUDE.md symlinks when new jobs are generated, ensuring all future jobs follow this pattern
- **Created symlinks in existing directories**: Added CLAUDE.md symlinks to all existing AGENTS.md locations:
  - Root directory
  - `.deepwork/jobs/test_job_flow/`
  - `.deepwork/jobs/update_job_schema/`
  - `doc/debugging_history/`
  - `src/deepwork/standard_jobs/deepwork_jobs/`

## Implementation Details
- Symlinks use relative path targets (`AGENTS.md` rather than absolute paths) to remain valid after directory moves or clones
- The deepreview job validates symlink existence and correctness, providing clear failure messages if symlinks are missing or incorrect
- Job creation script now includes symlink creation in its workflow and displays the symlink in the directory tree output

https://claude.ai/code/session_013LSePqqcsCg1d6now3qseB