### PR TITLE
feat(deepwork_jobs): add shared_jobs workflow for installing library jobs

### DIFF
--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=.deepwork/schemas/job.schema.json
 name: deepwork_jobs
-version: "1.5.1"
+version: "1.6.0"
 summary: "Creates and manages multi-step AI workflows. Use when defining, implementing, testing, or improving DeepWork jobs."
 common_job_info_provided_to_all_steps_at_runtime: |
   Core commands for managing DeepWork jobs. These commands help you define new multi-step
@@ -54,6 +54,11 @@ workflows:
     summary: "Analyze conversation history to improve job instructions and capture learnings"
     steps:
       - learn
+
+  - name: shared_jobs
+    summary: "Install library jobs from the DeepWork shared job library into the project"
+    steps:
+      - sync_shared_jobs
 
 steps:
   - id: define
@@ -268,3 +273,24 @@ steps:
           "Rules Job Removed": "`.deepwork/jobs/deepwork_rules/` is gone."
           "MCP Server Entry Removed": "The `deepwork serve` entry is removed from `.mcp.json` (or the file is deleted if empty)."
           "Library Jobs Offered": "If a flake.nix exists without DEEPWORK_ADDITIONAL_JOBS_FOLDERS, the user was offered library job setup. If no flake.nix exists, the Nix devshell option was mentioned. If already configured, nothing was said."
+
+  - id: sync_shared_jobs
+    name: "Sync Shared Jobs"
+    description: "Installs library jobs from the DeepWork shared job library into the project. Supports remote (GitHub) and local source paths."
+    instructions_file: steps/sync_shared_jobs.md
+    inputs:
+      - name: source
+        description: "Source for library jobs: 'remote' for GitHub, or a local path to a DeepWork repo checkout"
+    outputs:
+      installed_jobs:
+        type: files
+        description: "The job.yml files of newly installed library jobs"
+        required: true
+    dependencies: []
+    reviews:
+      - run_each: installed_jobs
+        quality_criteria:
+          "Valid Job Definition": "The job.yml is valid YAML with required fields (name, version, summary, steps)."
+          "Step Files Present": "All instructions_file paths referenced in job.yml exist."
+          "No Conflict": "Existing job handling was clean (new install, or user approved overwrite)."
+          "Sync Completed": "deepwork sync was run after installation."

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/sync_shared_jobs.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/sync_shared_jobs.md
@@ -1,0 +1,127 @@
+# Sync Shared Jobs
+
+## Objective
+
+Install library jobs from the DeepWork shared job library into the project's `.deepwork/jobs/` directory. Supports fetching from the remote GitHub repository or from a local DeepWork repo checkout (useful for maintainers developing new jobs).
+
+## Task
+
+### Step 1: Determine Source
+
+Use the AskUserQuestion tool to ask structured questions about the source:
+
+**Question**: "Where should library jobs be fetched from?"
+
+- **Remote (GitHub)** — Clone from the official DeepWork repository on GitHub. Best for most users.
+- **Local path** — Use a local checkout of the DeepWork repository. Best for maintainers testing new jobs before merging.
+
+If the user selects "Local path", ask for the filesystem path to the DeepWork repository root (e.g., `../deepwork` or `/home/user/code/deepwork`).
+
+### Step 2: Obtain Library Jobs
+
+#### Remote Source (GitHub)
+
+1. Create a temporary directory for the sparse checkout:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   ```
+2. Perform a sparse checkout of only the `library/jobs/` directory:
+   ```bash
+   git clone --filter=blob:none --sparse https://github.com/Unsupervisedcom/deepwork.git "$TMPDIR/deepwork"
+   cd "$TMPDIR/deepwork"
+   git sparse-checkout set library/jobs
+   ```
+3. Set `LIBRARY_PATH="$TMPDIR/deepwork/library/jobs"`
+
+#### Local Source
+
+1. Validate that the provided path exists and contains `library/jobs/`:
+   ```bash
+   ls "$LOCAL_PATH/library/jobs/"
+   ```
+2. If the directory doesn't exist, inform the user and ask for the correct path.
+3. Set `LIBRARY_PATH="$LOCAL_PATH/library/jobs"`
+
+### Step 3: Discover Available Jobs
+
+1. List all subdirectories of `$LIBRARY_PATH` that contain a `job.yml` file.
+2. For each discovered job, read the `job.yml` and extract:
+   - `name`
+   - `version`
+   - `summary`
+3. Check which jobs already exist in the project's `.deepwork/jobs/` directory.
+4. Present a table to the user:
+
+   | Job Name | Version | Summary | Status |
+   |----------|---------|---------|--------|
+   | spec_driven_development | 1.0.0 | Spec-driven development workflow... | New |
+   | another_job | 2.1.0 | Description... | Exists (v1.0.0) |
+
+### Step 4: Select Jobs to Install
+
+Use the AskUserQuestion tool to ask structured questions:
+
+**Question**: "Which jobs would you like to install?"
+
+- **All jobs** — Install every job from the library
+- **Select specific jobs** — Choose individual jobs to install
+
+If the user selects specific jobs, present the list and let them choose.
+
+For jobs that already exist in the project, ask:
+
+**Question**: "Job `[name]` already exists (v[existing_version]). How should this be handled?"
+
+- **Overwrite** — Replace with the library version (v[new_version])
+- **Skip** — Keep the existing version
+- **Backup and overwrite** — Back up existing to `.deepwork/jobs/[name].backup/` then install new version
+
+### Step 5: Copy Selected Jobs
+
+For each selected job:
+
+1. Copy the entire job directory (including `job.yml`, `steps/`, and any other files) from `$LIBRARY_PATH/[job_name]/` to `.deepwork/jobs/[job_name]/`.
+2. If "Backup and overwrite" was selected, first copy the existing directory to `.deepwork/jobs/[job_name].backup/`.
+3. Verify the copy was successful by checking that `job.yml` exists in the destination.
+
+### Step 6: Run DeepWork Sync
+
+Run `deepwork sync` to regenerate skill files for the newly installed jobs:
+
+```bash
+deepwork sync
+```
+
+Verify the sync completes without errors.
+
+### Step 7: Clean Up
+
+If the remote source was used, remove the temporary directory:
+
+```bash
+rm -rf "$TMPDIR"
+```
+
+### Step 8: Report Results
+
+Summarize what was done:
+
+- **Installed**: List each newly installed job with name and version
+- **Overwritten**: List jobs that were overwritten (with old and new versions)
+- **Skipped**: List jobs that were skipped
+- **Errors**: Report any issues encountered
+
+## Output
+
+### installed_jobs
+
+A list of `job.yml` file paths for each job that was installed or updated.
+
+**Location**: `.deepwork/jobs/[job_name]/job.yml` for each installed job.
+
+## Quality Criteria
+
+- All installed `job.yml` files are valid YAML with required fields (`name`, `version`, `summary`, `steps`)
+- All `instructions_file` paths referenced in each `job.yml` exist in the installed job directory
+- Existing job conflicts were handled according to user preference (new install, overwrite with approval, or skip)
+- `deepwork sync` was run after installation and completed successfully


### PR DESCRIPTION
## Summary

- Adds `shared_jobs` workflow with `sync_shared_jobs` step to the `deepwork_jobs` standard job
- Supports remote (GitHub sparse-checkout) and local filesystem sources for library job installation
- Bumps version `1.5.1` → `1.6.0`

## Test plan

- [ ] Run `deepwork install` in a test project — confirm `shared_jobs` appears in `get_workflows` output
- [ ] Start the workflow via MCP, test with local path pointing to the deepwork repo
- [ ] Verify installed jobs appear in `.deepwork/jobs/` and `deepwork sync` succeeds
- [ ] Test remote source with GitHub sparse-checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)