### PR TITLE
feat(library): add Quick Start snippets and shared jobs docs

### DIFF
--- a/library/jobs/README.md
+++ b/library/jobs/README.md
@@ -1,12 +1,62 @@
-# Job Library
+# Shared Jobs
 
-This directory contains a public library of example jobs that you can use as starting points for your own workflows. Each job demonstrates best practices for structuring multi-step tasks with DeepWork.
+DeepWork includes a library of reusable jobs that any project can adopt. These are pre-built, multi-step workflows covering common tasks like research, repository setup, platform engineering, and spec-driven development.
+
+## Enabling Shared Jobs
+
+The fastest way to add shared jobs to your project is with the `/deepwork` skill:
+
+```
+/deepwork shared_jobs
+```
+
+This walks you through configuring `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` so the DeepWork plugin discovers library jobs at runtime alongside your local jobs. Jobs are referenced in-place from a checkout of the DeepWork repo — they are never copied into your project, so you always get the latest version.
+
+## Available Jobs
+
+| Job | Description |
+|-----|-------------|
+| [Research](/docs/jobs/research) | Multi-workflow research suite — deep investigation, quick summaries, material ingestion, and reproduction planning |
+| [Platform Engineer](/docs/jobs/platform-engineer) | Incident response, observability, CI/CD, releases, security, cost management, and infrastructure |
+| [Repo](/docs/jobs/repo) | Audit and configure repositories — labels, branch protection, milestones, and boards |
+| [Spec-Driven Development](/docs/jobs/spec-driven-development) | Build features through executable specifications: constitution, specify, clarify, plan, tasks, implement |
+
+## How It Works
+
+Shared jobs are stored in the `library/jobs/` directory of the DeepWork repository. When you run the `shared_jobs` workflow, it:
+
+1. **Detects your setup** — checks for an existing local DeepWork checkout or sparse clone
+2. **Configures the source** — sets up a sparse checkout in `.deepwork/upstream/` or points to an existing local clone
+3. **Sets the environment variable** — adds `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` to your `flake.nix` shellHook (or shell profile)
+4. **Discovers jobs** — library jobs appear in `/deepwork` alongside your local and standard jobs
+
+## Creating Slash Commands for Jobs
+
+You can ask Claude to turn any job workflow into a slash command for quicker access. The easiest way is a one-liner from your terminal:
+
+```bash
+claude "Create a /research slash command from the deepwork research job with subcommands for each workflow"
+```
+
+Claude will create skill files under `.claude/skills/` so you can invoke workflows directly:
+
+```
+/research              # runs research (deep) workflow
+/research deep         # runs research (deep) workflow
+/research quick        # runs research (quick) workflow
+```
+
+You can also use dot notation for the skill name — `/research.deep` and `/research.quick` — which creates separate skill files for each workflow.
+
+### Why slash commands aren't created automatically
+
+DeepWork does not auto-generate slash commands for every job and workflow. Each slash command becomes a **skill** that is loaded into the agent's context — both for the user and for any sub-agents that spawn during a session. Auto-generating commands for every workflow across every installed job would flood the skill list, increasing token usage and making it harder for agents to select the right tool. Instead, users create slash commands only for the workflows they actually use frequently, keeping the skill surface lean and intentional.
 
 ## Purpose
 
 The job library provides:
 
-- **Inspiration**: See how others have structured complex workflows
+- **Ready-to-use workflows**: Start using proven multi-step workflows immediately
 - **Templates**: Copy and adapt jobs for your own use cases
 - **Learning**: Understand the job definition format through real examples
 
@@ -177,7 +227,7 @@ When you use a library job and discover improvements, you can contribute them ba
 ### The Learn Flow
 
 1. Run the library job in your project as normal
-2. Run `/deepwork deepwork_jobs learn` — the learn step classifies improvements as:
+2. Run `/deepwork learn` — the learn step classifies improvements as:
    - **Generalizable**: Improvements that benefit all users (update the library job)
    - **Bespoke**: Improvements specific to your project (update your local `AGENTS.md`)
 

--- a/library/jobs/platform_engineer/readme.md
+++ b/library/jobs/platform_engineer/readme.md
@@ -16,6 +16,15 @@ This job covers the full lifecycle of platform engineering work:
 - **Infrastructure**: Audit documentation, plan migrations, convert imperative to declarative
 - **Error tracking**: Set up exception monitoring (Sentry, etc.)
 
+## Quick Start
+
+Enable shared library jobs in your project, then start a platform engineering workflow:
+
+```
+/deepwork shared_jobs
+/deepwork platform_engineer incident_investigation
+```
+
 ## Workflows
 
 | Workflow | When to Use |

--- a/library/jobs/repo/readme.md
+++ b/library/jobs/repo/readme.md
@@ -11,6 +11,15 @@ Two workflows are provided:
 1. **setup** — Make a repo ready for work: create missing labels, check branch protection, verify milestones and boards
 2. **doctor** — Audit existing state and fix drift: find duplicates, enable missing protections, correct label drift, reconcile board items
 
+## Quick Start
+
+Enable shared library jobs in your project, then set up your repo:
+
+```
+/deepwork shared_jobs
+/deepwork repo setup
+```
+
 ## Provider Support
 
 The job detects the provider from `git remote get-url origin`:

--- a/library/jobs/research/readme.md
+++ b/library/jobs/research/readme.md
@@ -44,6 +44,15 @@ Ingest research material, analyze for reproducible claims, and create an enginee
 ingest_material → analyze → plan
 ```
 
+## Quick Start
+
+Enable shared library jobs in your project, then start a research workflow:
+
+```
+/deepwork shared_jobs
+/deepwork research research
+```
+
 ## Prerequisites
 
 - For **research** workflow: Browser tool access if using external platforms (Gemini, ChatGPT, etc.)

--- a/library/jobs/spec_driven_development/readme.md
+++ b/library/jobs/spec_driven_development/readme.md
@@ -15,6 +15,15 @@ The workflow progresses through six steps:
 5. **Tasks** - Break the plan into ordered, actionable development tasks
 6. **Implement** - Execute tasks to deliver the complete feature
 
+## Quick Start
+
+Enable shared library jobs in your project, then start spec-driven development:
+
+```
+/deepwork shared_jobs
+/deepwork spec_driven_development specify
+```
+
 ## When to Use
 
 This workflow is ideal for:

--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=.deepwork/schemas/job.schema.json
 name: deepwork_jobs
-version: "1.6.0"
+version: "1.7.0"
 summary: "Creates and manages multi-step AI workflows. Use when defining, implementing, testing, or improving DeepWork jobs."
 common_job_info_provided_to_all_steps_at_runtime: |
   Core commands for managing DeepWork jobs. These commands help you define new multi-step
@@ -199,6 +199,7 @@ steps:
           "Bespoke Learnings Captured": "Run-specific learnings were added to AGENTS.md."
           "File References Used": "AGENTS.md entries reference other files where appropriate."
           "Working Folder Correct": "AGENTS.md is in the correct working folder for the job."
+          "External Repo Handled": "If the job lives in an external repo (via DEEPWORK_ADDITIONAL_JOBS_FOLDERS), changes were committed and pushed per the user's preference. If the job is local, this criterion auto-passes."
 
   - id: fix_settings
     name: "Fix Settings Files"
@@ -276,15 +277,15 @@ steps:
 
   - id: sync_shared_jobs
     name: "Sync Shared Jobs"
-    description: "Installs library jobs from the DeepWork shared job library into the project. Supports remote (GitHub) and local source paths."
+    description: "Configures DEEPWORK_ADDITIONAL_JOBS_FOLDERS to reference library jobs from a local checkout or sparse clone. Never copies jobs into .deepwork/jobs/."
     instructions_file: steps/sync_shared_jobs.md
     inputs:
       - name: source
-        description: "Source for library jobs: 'remote' for GitHub, or a local path to a DeepWork repo checkout"
+        description: "Source for library jobs: 'local' for an existing deepwork checkout, 'remote' for sparse-checkout clone, or a custom path"
     outputs:
       installed_jobs:
         type: files
-        description: "The job.yml files of newly installed library jobs"
+        description: "The job.yml files available via the configured library path"
         required: true
     dependencies: []
     reviews:
@@ -292,5 +293,5 @@ steps:
         quality_criteria:
           "Valid Job Definition": "The job.yml is valid YAML with required fields (name, version, summary, steps)."
           "Step Files Present": "All instructions_file paths referenced in job.yml exist."
-          "No Conflict": "Existing job handling was clean (new install, or user approved overwrite)."
-          "Sync Completed": "deepwork sync was run after installation."
+          "Referenced Not Copied": "Library jobs are referenced via DEEPWORK_ADDITIONAL_JOBS_FOLDERS, not copied into .deepwork/jobs/."
+          "Env Var Configured": "DEEPWORK_ADDITIONAL_JOBS_FOLDERS is set for persistence (flake.nix, shellHook, or equivalent)."

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/learn.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/learn.md
@@ -17,14 +17,20 @@ Analyze the conversation history to extract learnings and improvements, then app
    - Identify which jobs and steps were executed
    - Note the order of execution
 
-2. **Identify the target folder**
+2. **Locate the job directory using `job_dir`**
+   - The MCP server returns `job_dir` (absolute path) when starting workflows — use this as the authoritative location
+   - The job may live in `.deepwork/jobs/`, `src/deepwork/standard_jobs/`, or an **external folder** via `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`
+   - Check if `job_dir` is inside the current project's git repo or in a **separate git repository** (e.g. a library checkout at `~/.keystone/*/deepwork/library/jobs/`)
+   - If `job_dir` is in a different git repo, note this — you'll need to handle commits/pushes separately in Step 8
+
+3. **Identify the AGENTS.md target folder**
    - This should be the deepest common folder that would contain all work on the topic in the future
    - Should be clear from conversation history where work was done
    - If unclear, run `git diff` to see where changes were made on the branch
 
-3. **If no job was specified**, ask the user:
+4. **If no job was specified**, ask the user:
    - "Which DeepWork job would you like me to learn from?"
-   - List available jobs from `.deepwork/jobs/`
+   - List available jobs (call `get_workflows` to see all discovered jobs)
 
 ### Step 2: Identify Points of Confusion and Inefficiency
 
@@ -80,8 +86,9 @@ For each learning identified, determine if it is:
 
 For each generalizable learning:
 
-1. **Locate the instruction file**
-   - Path: `.deepwork/jobs/[job_name]/steps/[step_id].md`
+1. **Locate the instruction file using `job_dir`**
+   - Path: `<job_dir>/steps/[step_id].md` (where `job_dir` was identified in Step 1)
+   - Do NOT assume `.deepwork/jobs/` — the job may live in an external folder
 
 2. **Make targeted improvements**
    - Add missing context or clarification
@@ -109,7 +116,7 @@ Review all instruction files for the job and identify content that:
 
 **Extract to shared files:**
 
-1. **Create shared files** in `.deepwork/jobs/[job_name]/steps/shared/`
+1. **Create shared files** in `<job_dir>/steps/shared/`
    - `conventions.md` - Coding/formatting conventions used across steps
    - `examples.md` - Common examples referenced by multiple steps
    - `schemas.md` - Data structures or formats used throughout
@@ -171,6 +178,31 @@ If instruction files were modified:
 1. **Bump version in job.yml**
    - Patch version (0.0.x) for instruction improvements
    - Minor version (0.x.0) if quality criteria changed
+
+### Step 8: Commit and Push Changes to External Job Repos
+
+If `job_dir` is in a **separate git repository** (outside the current project), you need to commit and push those changes independently.
+
+1. **Detect the external repo**
+   - Run `git -C <job_dir> rev-parse --show-toplevel` to find the repo root
+   - If it differs from the current project root, the job lives in an external repo
+
+2. **Commit changes in the external repo**
+   - `cd` to the external repo root
+   - Stage only the changed job files (e.g. `git add <job_dir>/`)
+   - Create a commit following Conventional Commits: `fix(jobs): improve <job_name> instructions from learn workflow`
+
+3. **Push strategy — ask the user**
+   - Ask: "The job `<job_name>` lives in an external repo at `<repo_root>`. How would you like to push these changes?"
+     - **Direct push to main**: Commit on main and push (for collaborators who prefer clean history)
+     - **PR from branch**: Create a feature branch, push, and open a PR (for non-collaborators or when review is desired)
+     - **PR from fork**: Fork the repo, push to fork, and open a PR (for non-collaborators without write access)
+   - If the user has previously expressed a preference, follow it without asking again
+
+4. **Execute the chosen strategy**
+   - For direct push: `git push origin main`
+   - For PR: Create branch `deepwork/learn-<job_name>`, push with `-u`, open PR via `gh pr create`
+   - For fork PR: Use `gh repo fork`, push to fork, open PR against upstream
 
 ## File Reference Patterns
 

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/sync_shared_jobs.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/sync_shared_jobs.md
@@ -2,126 +2,163 @@
 
 ## Objective
 
-Install library jobs from the DeepWork shared job library into the project's `.deepwork/jobs/` directory. Supports fetching from the remote GitHub repository or from a local DeepWork repo checkout (useful for maintainers developing new jobs).
+Make DeepWork library jobs available in the project by configuring `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` to reference them in-place. Jobs are **never copied** into `.deepwork/jobs/` — they are referenced from a local checkout or a sparse-checkout clone.
+
+## Important
+
+- **Do NOT copy job directories into `.deepwork/jobs/`.** Library jobs must be referenced via `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` so they stay up-to-date with upstream.
+- **Do NOT run `deepwork sync`.** DeepWork is now a Claude Code plugin that auto-discovers jobs at runtime.
 
 ## Task
 
-### Step 1: Determine Source
+### Step 1: Detect Existing Configuration
 
-Use the AskUserQuestion tool to ask structured questions about the source:
+Before asking the user anything, check for existing setup:
 
-**Question**: "Where should library jobs be fetched from?"
-
-- **Remote (GitHub)** — Clone from the official DeepWork repository on GitHub. Best for most users.
-- **Local path** — Use a local checkout of the DeepWork repository. Best for maintainers testing new jobs before merging.
-
-If the user selects "Local path", ask for the filesystem path to the DeepWork repository root (e.g., `../deepwork` or `/home/user/code/deepwork`).
-
-### Step 2: Obtain Library Jobs
-
-#### Remote Source (GitHub)
-
-1. Create a temporary directory for the sparse checkout:
+1. **Check environment variable**:
    ```bash
-   TMPDIR=$(mktemp -d)
+   echo "${DEEPWORK_ADDITIONAL_JOBS_FOLDERS:-not set}"
    ```
-2. Perform a sparse checkout of only the `library/jobs/` directory:
+
+2. **Check flake.nix** (if it exists):
    ```bash
-   git clone --filter=blob:none --sparse https://github.com/Unsupervisedcom/deepwork.git "$TMPDIR/deepwork"
-   cd "$TMPDIR/deepwork"
-   git sparse-checkout set library/jobs
+   grep -q 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS' flake.nix && echo "configured" || echo "not configured"
    ```
-3. Set `LIBRARY_PATH="$TMPDIR/deepwork/library/jobs"`
 
-#### Local Source
+3. **Check for local deepwork checkout** — look for a sibling directory:
+   ```bash
+   ls ../deepwork/library/jobs/ 2>/dev/null && echo "local checkout found" || echo "no local checkout"
+   ```
 
-1. Validate that the provided path exists and contains `library/jobs/`:
+4. **Check for existing sparse checkout**:
+   ```bash
+   ls .deepwork/upstream/library/jobs/ 2>/dev/null && echo "sparse checkout found" || echo "no sparse checkout"
+   ```
+
+If a working configuration is already detected (env var set and pointing to a valid directory):
+1. **Always pull updates** on any sparse checkout found at `.deepwork/upstream/`:
+   ```bash
+   git -C .deepwork/upstream pull
+   ```
+2. Report what's configured and list available jobs.
+3. Ask if the user wants to reconfigure the source.
+
+### Step 2: Determine Source
+
+Based on detection results, use AskUserQuestion to offer appropriate options:
+
+**Question**: "How should library jobs be sourced?"
+
+- **Local checkout** (if `../deepwork/library/jobs/` exists) — Point to the existing local DeepWork checkout. Best for maintainers or when a local clone already exists. *(Recommended when detected)*
+- **Sparse checkout** — Clone the DeepWork repo into `.deepwork/upstream/` with sparse checkout for just `library/jobs/`. Best for most users who want live upstream updates.
+- **Custom local path** — Specify a custom path to a DeepWork repository checkout.
+
+If the user selects "Custom local path", ask for the filesystem path to the DeepWork repository root.
+
+### Step 3: Set Up the Source
+
+#### Local Checkout (e.g., `../deepwork`)
+
+1. Validate the path contains `library/jobs/`:
    ```bash
    ls "$LOCAL_PATH/library/jobs/"
    ```
-2. If the directory doesn't exist, inform the user and ask for the correct path.
-3. Set `LIBRARY_PATH="$LOCAL_PATH/library/jobs"`
+2. Resolve the absolute path:
+   ```bash
+   LIBRARY_PATH=$(cd "$LOCAL_PATH/library/jobs" && pwd)
+   ```
 
-### Step 3: Discover Available Jobs
+#### Sparse Checkout (into `.deepwork/upstream/`)
+
+1. If `.deepwork/upstream/` doesn't exist, create it:
+   ```bash
+   git clone --sparse --filter=blob:none \
+     https://github.com/Unsupervisedcom/deepwork.git \
+     .deepwork/upstream
+   git -C .deepwork/upstream sparse-checkout set --cone library/jobs/
+   ```
+2. If it already exists, update it:
+   ```bash
+   git -C .deepwork/upstream pull
+   ```
+3. Ensure `.deepwork/upstream/` is in `.gitignore`.
+4. Set `LIBRARY_PATH="$REPO_ROOT/.deepwork/upstream/library/jobs"`
+
+### Step 4: Configure `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`
+
+The env var must be set so the DeepWork plugin discovers library jobs at runtime.
+
+1. **If `flake.nix` exists**, check whether it already sets `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`:
+   - If yes, verify it points to the correct path. Update if needed.
+   - If no, add the shellHook export. Example for sparse checkout:
+     ```nix
+     shellHook = ''
+       export REPO_ROOT=$(git rev-parse --show-toplevel)
+       # Clone or update DeepWork library jobs
+       if [ ! -d "$REPO_ROOT/.deepwork/upstream" ]; then
+         git clone --sparse --filter=blob:none \
+           https://github.com/Unsupervisedcom/deepwork.git \
+           "$REPO_ROOT/.deepwork/upstream"
+         git -C "$REPO_ROOT/.deepwork/upstream" sparse-checkout set --cone library/jobs/
+       else
+         # Pull updates in background to keep library jobs current
+         git -C "$REPO_ROOT/.deepwork/upstream" pull --quiet &
+       fi
+       export DEEPWORK_ADDITIONAL_JOBS_FOLDERS="$REPO_ROOT/.deepwork/upstream/library/jobs"
+     '';
+     ```
+   - For a local checkout, the export is simpler:
+     ```nix
+     export DEEPWORK_ADDITIONAL_JOBS_FOLDERS="$REPO_ROOT/../deepwork/library/jobs"
+     ```
+
+2. **If no `flake.nix`**, inform the user they need to set the env var in their shell:
+   ```bash
+   export DEEPWORK_ADDITIONAL_JOBS_FOLDERS="/path/to/deepwork/library/jobs"
+   ```
+
+3. **For the current session**, export the variable so jobs are immediately available:
+   ```bash
+   export DEEPWORK_ADDITIONAL_JOBS_FOLDERS="$LIBRARY_PATH"
+   ```
+
+### Step 5: Discover and Report Available Jobs
 
 1. List all subdirectories of `$LIBRARY_PATH` that contain a `job.yml` file.
-2. For each discovered job, read the `job.yml` and extract:
-   - `name`
-   - `version`
-   - `summary`
-3. Check which jobs already exist in the project's `.deepwork/jobs/` directory.
-4. Present a table to the user:
+2. For each discovered job, read the `job.yml` and extract `name`, `version`, `summary`.
+3. Present a table:
 
-   | Job Name | Version | Summary | Status |
-   |----------|---------|---------|--------|
-   | spec_driven_development | 1.0.0 | Spec-driven development workflow... | New |
-   | another_job | 2.1.0 | Description... | Exists (v1.0.0) |
+   | Job Name | Version | Summary |
+   |----------|---------|---------|
+   | platform_engineer | 1.0.0 | Platform engineering workflows... |
+   | research | 1.0.0 | Research workflows... |
 
-### Step 4: Select Jobs to Install
+4. Verify the jobs are discoverable by checking if they appear alongside local jobs.
 
-Use the AskUserQuestion tool to ask structured questions:
+### Step 6: Clean Up Stale Copies
 
-**Question**: "Which jobs would you like to install?"
+Check `.deepwork/jobs/` for any previously-copied library jobs that now exist in the referenced library path. If found, inform the user and offer to remove them (they are now redundant since the library reference handles discovery).
 
-- **All jobs** — Install every job from the library
-- **Select specific jobs** — Choose individual jobs to install
+### Step 7: Report Results
 
-If the user selects specific jobs, present the list and let them choose.
-
-For jobs that already exist in the project, ask:
-
-**Question**: "Job `[name]` already exists (v[existing_version]). How should this be handled?"
-
-- **Overwrite** — Replace with the library version (v[new_version])
-- **Skip** — Keep the existing version
-- **Backup and overwrite** — Back up existing to `.deepwork/jobs/[name].backup/` then install new version
-
-### Step 5: Copy Selected Jobs
-
-For each selected job:
-
-1. Copy the entire job directory (including `job.yml`, `steps/`, and any other files) from `$LIBRARY_PATH/[job_name]/` to `.deepwork/jobs/[job_name]/`.
-2. If "Backup and overwrite" was selected, first copy the existing directory to `.deepwork/jobs/[job_name].backup/`.
-3. Verify the copy was successful by checking that `job.yml` exists in the destination.
-
-### Step 6: Run DeepWork Sync
-
-Run `deepwork sync` to regenerate skill files for the newly installed jobs:
-
-```bash
-deepwork sync
-```
-
-Verify the sync completes without errors.
-
-### Step 7: Clean Up
-
-If the remote source was used, remove the temporary directory:
-
-```bash
-rm -rf "$TMPDIR"
-```
-
-### Step 8: Report Results
-
-Summarize what was done:
-
-- **Installed**: List each newly installed job with name and version
-- **Overwritten**: List jobs that were overwritten (with old and new versions)
-- **Skipped**: List jobs that were skipped
-- **Errors**: Report any issues encountered
+Summarize:
+- **Source configured**: The path and method (local checkout / sparse checkout)
+- **Available jobs**: List of jobs now available from the library
+- **Configuration location**: Where the env var is set (flake.nix / shell / etc.)
+- **Cleaned up**: Any stale copies that were removed
 
 ## Output
 
 ### installed_jobs
 
-A list of `job.yml` file paths for each job that was installed or updated.
+A list of `job.yml` file paths for each job available via the configured library path.
 
-**Location**: `.deepwork/jobs/[job_name]/job.yml` for each installed job.
+**Location**: `$LIBRARY_PATH/[job_name]/job.yml` for each available job.
 
 ## Quality Criteria
 
-- All installed `job.yml` files are valid YAML with required fields (`name`, `version`, `summary`, `steps`)
-- All `instructions_file` paths referenced in each `job.yml` exist in the installed job directory
-- Existing job conflicts were handled according to user preference (new install, overwrite with approval, or skip)
-- `deepwork sync` was run after installation and completed successfully
+- Library jobs are referenced via `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`, NOT copied into `.deepwork/jobs/`
+- All referenced `job.yml` files are valid YAML with required fields (`name`, `version`, `summary`, `steps`)
+- All `instructions_file` paths referenced in each `job.yml` exist
+- The env var is configured for persistence (in flake.nix, shellHook, or equivalent)
+- No stale copied library jobs remain in `.deepwork/jobs/`


### PR DESCRIPTION
## Summary
- Rewrite `library/jobs/README.md` as a "Shared Jobs" intro page explaining how to enable shared jobs via `/deepwork deepwork_jobs shared_jobs`
- Add Quick Start section to each job readme (research, platform_engineer, repo, spec_driven_development) with enable + run snippets
- Update shared_jobs workflow step and teach learn workflow to handle external job repos

## Test plan
- [ ] Verify docs site shows "Shared Jobs" as first entry in Jobs sidebar at `/docs/jobs`
- [ ] Verify each job page shows Quick Start section with correct `/deepwork` commands
- [ ] Clear localStorage cache and reload to test fresh fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)