### PR TITLE
Fix marketplace version drift and sync in release workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "deepwork",
       "description": "Framework for AI-powered multi-step workflows with quality gates",
-      "version": "0.8.0",
+      "version": "0.9.7",
       "source": "./plugins/claude",
       "author": {
         "name": "DeepWork"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -122,6 +122,18 @@ jobs:
             grep '"version"' "$PLUGIN_FILE"
           done
 
+      - name: Update marketplace plugin versions
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          # Update the deepwork plugin version in marketplace.json
+          # Use jq to update only the deepwork plugin entry's version
+          jq --arg v "$VERSION" '(.plugins[] | select(.name == "deepwork")).version = $v' \
+            .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
+          mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+          echo "Updated .claude-plugin/marketplace.json:"
+          jq '.plugins[] | select(.name == "deepwork") | .version' .claude-plugin/marketplace.json
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -139,7 +151,7 @@ jobs:
       - name: Commit and push
         run: |
           VERSION="${{ inputs.version }}"
-          git add CHANGELOG.md pyproject.toml uv.lock $(find . -path '*/.claude-plugin/plugin.json')
+          git add CHANGELOG.md pyproject.toml uv.lock .claude-plugin/marketplace.json $(find . -path '*/.claude-plugin/plugin.json')
           git commit -m "Release v${VERSION}"
           git push -u origin "release/${VERSION}"
 


### PR DESCRIPTION
## Summary
- Updated `.claude-plugin/marketplace.json` deepwork plugin version from `0.8.0` to `0.9.7` (was never updated past 0.8.0)
- Added a step to `prepare-release.yml` to automatically update the marketplace version during releases, preventing future drift

## Test plan
- [ ] Verify marketplace.json shows correct version
- [ ] Run a dry-run of prepare-release workflow to confirm jq step works

🤖 Generated with [Claude Code](https://claude.com/claude-code)