### PR TITLE
Remove legacy skill folder cleanup from migration steps

### DIFF
--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -215,8 +215,6 @@ steps:
     reviews:
       - run_each: step
         quality_criteria:
-          "DeepWork Skills Removed": "`Skill(...)` entries matching jobs in `.deepwork/jobs/` are removed."
-          "Non-DeepWork Skills Preserved": "Skills NOT matching DeepWork jobs are left intact."
           "Stale make_new_job.sh Removed": "Stale `Bash(...)` permissions referencing `.deepwork/jobs/deepwork_jobs/make_new_job.sh` are removed."
           "Rules Hooks Removed": "All DeepWork Rules hooks and permissions are removed."
           "Duplicate Hooks Removed": "Duplicate hook entries are consolidated or removed."
@@ -255,7 +253,7 @@ steps:
 
   - id: errata
     name: "Clean Up Errata"
-    description: "Removes obsolete files and folders from prior DeepWork versions, including old skill directories, temp files, and deprecated configurations."
+    description: "Removes obsolete files and folders from prior DeepWork versions, including temp files and deprecated configurations."
     instructions_file: steps/errata.md
     outputs: {}
     inputs:
@@ -268,8 +266,6 @@ steps:
       - run_each: step
         additional_review_guidance: "Complete this review in a small number of turns - tee up every data request you need in your first call."
         quality_criteria:
-          "Legacy Job Skills Removed": "Legacy skill folders for each job are removed from `.claude/skills/` and `.gemini/skills/`."
-          "Deepwork Skill Removed": "The `deepwork` skill folder has been removed from `.claude/skills/deepwork/` and `.gemini/skills/deepwork/` (now provided by the plugin system)."
           "Rules Folder Removed": "`.deepwork/rules/` folder is gone."
           "Rules Job Removed": "`.deepwork/jobs/deepwork_rules/` is gone."
           "MCP Server Entry Removed": "The `deepwork serve` entry is removed from `.mcp.json` (or the file is deleted if empty)."

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/errata.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/errata.md
@@ -8,56 +8,7 @@ Remove obsolete files and folders from prior DeepWork versions. This final step 
 
 Identify and clean up deprecated files and folders.
 
-### Step 1: Remove Legacy Job Skill Folders
-
-Old DeepWork versions created individual skill folders for each job and step. These need to be removed, including the main `deepwork` skill folder (which is now provided by the plugin system and no longer belongs in the repo).
-
-**Process:**
-
-1. **List all jobs** in `.deepwork/jobs/`:
-   ```bash
-   ls .deepwork/jobs/
-   ```
-
-2. **Kick off a single sub-agent** to remove all legacy skill folders for every job at once. Be concise — output minimal text, only reporting what was removed or confirming nothing was found. The sub-agent should:
-   - For each job in `.deepwork/jobs/`, search in both `.claude/skills/` and `.gemini/skills/` for folders matching:
-     - `{job_name}/` - folder named exactly like the job
-     - `{job_name}.*/` - folders starting with the job name followed by a period (e.g., `my_job.step1/`, `my_job.step2/`)
-   - Remove each matching folder
-   - **Also remove** `.claude/skills/deepwork/` and `.gemini/skills/deepwork/` — the `deepwork` skill is now provided by the plugin system and should not exist in the repo
-   - Report only: what was removed (one line per folder) or "No legacy folders found"
-
-   **Example commands for a job named `competitive_research`:**
-   ```bash
-   # Find and remove from .claude/skills/
-   rm -rf .claude/skills/competitive_research/ 2>/dev/null
-   rm -rf .claude/skills/competitive_research.*/ 2>/dev/null
-
-   # Find and remove from .gemini/skills/
-   rm -rf .gemini/skills/competitive_research/ 2>/dev/null
-   rm -rf .gemini/skills/competitive_research.*/ 2>/dev/null
-   ```
-
-3. **Remove the `deepwork` skill folders** (now provided by the plugin):
-   ```bash
-   rm -rf .claude/skills/deepwork/ 2>/dev/null
-   rm -rf .gemini/skills/deepwork/ 2>/dev/null
-   ```
-
-**What this removes:**
-```
-.claude/skills/
-├── competitive_research/     <- REMOVE (legacy job folder)
-├── competitive_research.discover/  <- REMOVE (legacy step folder)
-├── competitive_research.analyze/   <- REMOVE (legacy step folder)
-├── deepwork/                 <- REMOVE (now provided by plugin)
-└── some_other_job/           <- REMOVE (legacy job folder)
-```
-
-**Do NOT remove:**
-- Any skill folders that don't match job names in `.deepwork/jobs/` (and aren't `deepwork/`)
-
-### Step 2: Clean Temp Files
+### Step 1: Clean Temp Files
 
 Check `.deepwork/tmp/` for accumulated temporary files:
 
@@ -82,7 +33,7 @@ rm -rf .deepwork/tmp/rules/queue/*.json 2>/dev/null
 find .deepwork/tmp -type d -empty -delete 2>/dev/null
 ```
 
-### Step 3: Remove Rules Folder (Fully Deprecated)
+### Step 2: Remove Rules Folder (Fully Deprecated)
 
 DeepWork Rules have been completely removed from the system. Delete the `.deepwork/rules/` folder and all related items:
 
@@ -92,7 +43,7 @@ rm -rf .deepwork/tmp/rules/ 2>/dev/null
 rm -rf .deepwork/jobs/deepwork_rules/ 2>/dev/null
 ```
 
-### Step 4: Update Config Version
+### Step 3: Update Config Version
 
 Check `.deepwork/config.yml` for outdated version format. If the file does not exist, skip this step.
 
@@ -116,7 +67,7 @@ platforms:
 
 Update if needed to match current schema expectations.
 
-### Step 5: Remove `deepwork serve` from `.mcp.json`
+### Step 4: Remove `deepwork serve` from `.mcp.json`
 
 Old DeepWork versions added a `deepwork serve` MCP server entry directly to the repo's `.mcp.json` file. This is now handled by the plugin system and must be removed.
 
@@ -164,7 +115,7 @@ Old DeepWork versions added a `deepwork serve` MCP server entry directly to the 
 }
 ```
 
-### Step 6: Remove Other Obsolete Files
+### Step 5: Remove Other Obsolete Files
 
 Check for and remove other obsolete files:
 
@@ -176,7 +127,7 @@ Check for and remove other obsolete files:
 | `.claude/commands/` | Generated commands | Keep (current system) |
 | `.claude/settings.local.json` | Local overrides | Keep (user settings) |
 
-### Step 7: Library Job Access via Nix Dev Shell
+### Step 6: Library Job Access via Nix Dev Shell
 
 Library jobs replace some patterns previously handled by copied job files. This step ensures users are aware of the recommended setup path.
 
@@ -232,7 +183,7 @@ Check whether the project uses a Nix flake devshell and whether shared library j
 
    Do not go into detail — just make the user aware.
 
-### Step 8: Verify Git Status
+### Step 7: Verify Git Status
 
 Check that the cleanup hasn't left untracked garbage:
 
@@ -247,8 +198,6 @@ git status
 
 ## Quality Criteria
 
-- Legacy skill folders for each job are removed from `.claude/skills/` and `.gemini/skills/`
-- The `deepwork` skill folder has been removed from `.claude/skills/deepwork/` and `.gemini/skills/deepwork/` (now provided by the plugin system)
 - `.deepwork/rules/` folder is gone
 - `.deepwork/jobs/deepwork_rules/` is gone
 - The `deepwork serve` entry is removed from `.mcp.json` (or the file is deleted if empty)

--- a/src/deepwork/standard_jobs/deepwork_jobs/steps/fix_settings.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/steps/fix_settings.md
@@ -24,32 +24,9 @@ First, get the list of jobs that exist in `.deepwork/jobs/`:
 ls .deepwork/jobs/
 ```
 
-Note these job names - you will use them to identify which `Skill(...)` entries to remove.
+Note these job names for identifying legacy artifacts.
 
-### Step 3: Remove DeepWork Skill Permissions
-
-Look for and **remove** `Skill(...)` permission entries that match DeepWork jobs. Only remove entries where the skill name matches a job in `.deepwork/jobs/`.
-
-**What to look for:**
-```json
-"permissions": {
-  "allow": [
-    "Skill(deepwork_jobs)",           // Remove if 'deepwork_jobs' is in .deepwork/jobs/
-    "Skill(deepwork_jobs.define)",    // Remove - matches job_name.step pattern
-    "Skill(competitive_research)",    // Remove if 'competitive_research' is in .deepwork/jobs/
-    "Skill(my_custom_skill)",         // KEEP - not a DeepWork job
-    ...
-  ]
-}
-```
-
-**IMPORTANT:** Only remove skills that:
-- Exactly match a job name in `.deepwork/jobs/` (e.g., `Skill(job_name)`)
-- Match the pattern `job_name.step_name` where `job_name` is in `.deepwork/jobs/`
-
-**DO NOT remove** skills that don't match DeepWork jobs - the user may have created these manually for other purposes.
-
-### Step 4: Remove Duplicate Hooks
+### Step 3: Remove Duplicate Hooks
 
 Check for duplicate hook entries in the `hooks` section. Prior versions sometimes added the same hook multiple times.
 
@@ -71,7 +48,7 @@ Check for duplicate hook entries in the `hooks` section. Prior versions sometime
 
 Keep only one instance of each unique hook.
 
-### Step 5: Remove Hardcoded User Paths
+### Step 4: Remove Hardcoded User Paths
 
 Search for and remove any hardcoded paths that reference specific user directories:
 
@@ -82,7 +59,7 @@ Search for and remove any hardcoded paths that reference specific user directori
 
 These should either be removed or replaced with relative paths.
 
-### Step 6: Remove DeepWork Rules Hooks (Fully Deprecated)
+### Step 5: Remove DeepWork Rules Hooks (Fully Deprecated)
 
 DeepWork Rules have been completely removed from the system. Remove ALL hooks related to rules:
 
@@ -92,12 +69,10 @@ DeepWork Rules have been completely removed from the system. Remove ALL hooks re
 - Any hook referencing `.deepwork/jobs/deepwork_rules/hooks/`
 - Any hook referencing `.deepwork/rules/`
 
-**Also remove these permissions if present:**
-- `Skill(deepwork_rules)`
-- `Skill(deepwork_rules.define)`
+**Also remove this permission if present:**
 - `Bash(rm -rf .deepwork/tmp/rules/queue/*.json)`
 
-### Step 7: Remove Other Deprecated Commands
+### Step 6: Remove Other Deprecated Commands
 
 Remove hooks referencing other deprecated DeepWork commands:
 
@@ -105,7 +80,7 @@ Remove hooks referencing other deprecated DeepWork commands:
 - `deepwork hook *` - The entire hook subcommand is deprecated
 - References to any `.deepwork/jobs/*/hooks/` scripts
 
-### Step 8: Clean Up Empty Sections
+### Step 7: Clean Up Empty Sections
 
 If after cleanup any sections are empty, consider removing them:
 
@@ -116,7 +91,7 @@ If after cleanup any sections are empty, consider removing them:
 }
 ```
 
-### Step 9: Validate JSON
+### Step 8: Validate JSON
 
 After all edits, ensure the file is valid JSON:
 
@@ -145,10 +120,6 @@ If there are syntax errors, fix them before proceeding.
   },
   "permissions": {
     "allow": [
-      "Skill(competitive_research)",
-      "Skill(competitive_research.discover_competitors)",
-      "Skill(deepwork_jobs)",
-      "Skill(deepwork_jobs.define)",
       "Read(./.deepwork/**)",
       "WebSearch"
     ]
@@ -171,7 +142,6 @@ If there are syntax errors, fix them before proceeding.
 
 ## Important Notes
 
-1. **Don't remove non-DeepWork permissions** - Keep permissions like `WebSearch`, `Read(...)`, `Bash(...)` that aren't related to old DeepWork skills
-2. **Remove stale `make_new_job.sh` permissions** - Remove any `Bash(...)` permission referencing `.deepwork/jobs/deepwork_jobs/make_new_job.sh` — this script now lives in the package and is accessed via the `job_dir` path
-3. **Be conservative** - If unsure whether something is legacy, ask the user
-4. **Document changes** - Note what was removed for the final summary
+1. **Remove stale `make_new_job.sh` permissions** - Remove any `Bash(...)` permission referencing `.deepwork/jobs/deepwork_jobs/make_new_job.sh` — this script now lives in the package and is accessed via the `job_dir` path
+2. **Be conservative** - If unsure whether something is legacy, ask the user
+3. **Document changes** - Note what was removed for the final summary


### PR DESCRIPTION
## Summary
This PR removes instructions and quality criteria related to cleaning up legacy DeepWork skill folders (`.claude/skills/` and `.gemini/skills/`), as this cleanup is no longer part of the migration process.

## Key Changes

- **errata.md**: Removed "Step 1: Remove Legacy Job Skill Folders" section that instructed users to delete job-specific skill folders and the `deepwork` skill folder from `.claude/skills/` and `.gemini/skills/`. Renumbered subsequent steps accordingly (Steps 2-8 → Steps 1-7).

- **fix_settings.md**: Removed "Step 3: Remove DeepWork Skill Permissions" section that instructed users to remove `Skill(...)` permission entries matching DeepWork jobs. Renumbered subsequent steps accordingly (Steps 4-9 → Steps 3-8). Updated the "Important Notes" section to remove references to non-DeepWork permissions preservation.

- **job.yml**: 
  - Removed quality criteria from `fix_settings` step: "DeepWork Skills Removed" and "Non-DeepWork Skills Preserved"
  - Removed quality criteria from `errata` step: "Legacy Job Skills Removed" and "Deepwork Skill Removed"
  - Updated `errata` step description to remove mention of "old skill directories"

## Rationale
These changes reflect that legacy skill folder cleanup is no longer required as part of the DeepWork migration process, simplifying the migration steps for users.

https://claude.ai/code/session_01DoFZdJRYKPeaHYGY5Fedbw