### PR TITLE
feat(standard_jobs): add record job for capturing and automating user processes

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -65,7 +65,8 @@ deepwork/                       # DeepWork tool repository
 │       │   └── gemini_hook.sh  # Shell wrapper for Gemini CLI
 │       ├── standard_jobs/      # Built-in job definitions
 │       │   ├── deepwork_jobs/
-│       │   └── deepwork_reviews/
+│       │   ├── deepwork_reviews/
+│       │   └── record/
 │       ├── review/             # DeepWork Reviews system
 │       │   ├── config.py       # .deepreview config parsing + data models
 │       │   ├── discovery.py    # Find .deepreview files in project tree

--- a/specs/deepwork/jobs/JOBS-REQ-011-record-standard-job.md
+++ b/specs/deepwork/jobs/JOBS-REQ-011-record-standard-job.md
@@ -15,20 +15,22 @@ The `record` standard job enables AI agents to observe a user performing a proce
 
 ### JOBS-REQ-011.2: Observe Step
 
-1. The `observe` step MUST accept two user-provided inputs: `process_name` and `process_description`.
-2. The `observe` step MUST produce an `observation_log.md` output file.
-3. The observation log MUST capture actions, tools used, decisions, and outcomes chronologically.
+1. The `observe` step MUST NOT require any user-provided inputs.
+2. The `observe` step MUST have empty outputs (`{}`).
+3. The `observe` step MUST instruct the agent to start immediately without asking upfront questions.
+4. The `observe` step MUST instruct the agent to use AskUserQuestion to solicit reasoning when the user takes actions whose purpose is unclear.
 
 ### JOBS-REQ-011.3: Document Step
 
-1. The `document` step MUST consume `observation_log.md` from the `observe` step.
+1. The `document` step MUST NOT consume file inputs from the observe step.
 2. The `document` step MUST produce a `process_document.md` output file.
-3. The process document MUST include a tool inventory, structured steps with inputs and outputs, and data flow.
-4. The `document` step MUST have quality reviews validating complete coverage, clear structure, and tool inventory.
+3. The `document` step MUST instruct the agent to synthesize the process from conversation history.
+4. The `document` step MUST instruct the agent to ask the user to confirm: the process purpose, a name for the process, and which inputs are variable vs. fixed.
+5. The `document` step MUST have quality reviews validating complete coverage, clear structure, and incorporation of user clarification.
 
 ### JOBS-REQ-011.4: Reflect Step
 
-1. The `reflect` step MUST consume both `observation_log.md` and `process_document.md` from prior steps.
+1. The `reflect` step MUST consume `process_document.md` from the document step.
 2. The `reflect` step MUST produce a `reflection.md` output file.
 3. The reflection MUST identify stumbling blocks with mitigation strategies and efficiency improvements with expected benefits.
 4. The `reflect` step MUST have quality reviews validating actionable improvements, stumbling block identification, and evidence grounding.

--- a/specs/deepwork/jobs/JOBS-REQ-011-record-standard-job.md
+++ b/specs/deepwork/jobs/JOBS-REQ-011-record-standard-job.md
@@ -1,0 +1,41 @@
+# JOBS-REQ-011: Record Standard Job
+
+## Overview
+
+The `record` standard job enables AI agents to observe a user performing a process, document it, reflect on improvements, and generate a reusable DeepWork job definition from the recording. It ships as a standard job bundled with the DeepWork package.
+
+## Requirements
+
+### JOBS-REQ-011.1: Job Structure
+
+1. The `record` standard job MUST be located in `src/deepwork/standard_jobs/record/`.
+2. The job MUST contain a valid `job.yml` that passes schema validation (see JOBS-REQ-002).
+3. The job MUST define exactly four steps: `observe`, `document`, `reflect`, and `generate_job`.
+4. The job MUST define a `record` workflow that sequences all four steps in order.
+
+### JOBS-REQ-011.2: Observe Step
+
+1. The `observe` step MUST accept two user-provided inputs: `process_name` and `process_description`.
+2. The `observe` step MUST produce an `observation_log.md` output file.
+3. The observation log MUST capture actions, tools used, decisions, and outcomes chronologically.
+
+### JOBS-REQ-011.3: Document Step
+
+1. The `document` step MUST consume `observation_log.md` from the `observe` step.
+2. The `document` step MUST produce a `process_document.md` output file.
+3. The process document MUST include a tool inventory, structured steps with inputs and outputs, and data flow.
+4. The `document` step MUST have quality reviews validating complete coverage, clear structure, and tool inventory.
+
+### JOBS-REQ-011.4: Reflect Step
+
+1. The `reflect` step MUST consume both `observation_log.md` and `process_document.md` from prior steps.
+2. The `reflect` step MUST produce a `reflection.md` output file.
+3. The reflection MUST identify stumbling blocks with mitigation strategies and efficiency improvements with expected benefits.
+4. The `reflect` step MUST have quality reviews validating actionable improvements, stumbling block identification, and evidence grounding.
+
+### JOBS-REQ-011.5: Generate Job Step
+
+1. The `generate_job` step MUST consume `process_document.md` and `reflection.md` from prior steps.
+2. The `generate_job` step MUST produce a `job_created.md` confirmation file.
+3. The `generate_job` step MUST defer to the `deepwork_jobs/new_job` workflow as a nested workflow for job creation.
+4. The `generate_job` step MUST use the process document and reflection to inform the nested workflow rather than starting from scratch.

--- a/src/deepwork/standard_jobs/record/.deepreview
+++ b/src/deepwork/standard_jobs/record/.deepreview
@@ -1,0 +1,76 @@
+job_definition_review:
+  description: "Review job.yml and step instructions for correctness, completeness, and coherence as a holistic workflow."
+  match:
+    include:
+      - "job.yml"
+      - "steps/*.md"
+  review:
+    strategy: matches_together
+    instructions: |
+      Review this DeepWork job definition (job.yml) and its step instruction files
+      (steps/*.md) holistically. Check that they form a coherent, well-structured
+      workflow that an AI agent can execute reliably.
+
+      ## Reference Material
+
+      For reference on correct job structure and best practices, read the following files from your plugin:
+      - `job.yml.template` — canonical job.yml structure with all supported fields
+      - `job.yml.example` — a complete working example (competitive research job)
+      - `step_instruction.md.template` — expected structure for step instruction files
+      - `research_report_job_best_practices.md` — design patterns for report-type jobs
+
+      ## What to Check
+
+      ### 1. job.yml Structure
+      - Has required fields: `name`, `version`, `summary`, `workflows`, `steps`
+      - `name` is lowercase with underscores only
+      - `summary` is concise (under 200 characters) and descriptive enough to let a user know what the job does
+      - `version` follows semantic versioning (e.g., "1.0.0")
+      - `common_job_info_provided_to_all_steps_at_runtime` provides useful shared context (problem domain, terminology, conventions, constraints)
+
+      ### 2. Workflow Coherence
+      - Each workflow's steps form a logical sequence toward a clear goal
+      - Step dependencies are declared correctly (no missing or extraneous deps)
+      - No circular dependencies exist
+
+      ### 3. Input/Output Chain
+      - Each step has at least one output
+      - File inputs reference outputs from steps listed in that step's dependencies
+      - `from_step` values match actual step IDs that produce the referenced file
+      - The output chain creates a logical data flow through the workflow
+      - Intermediate outputs that are not meant to be persisted should be in .deepwork/tmp (and the name should indicate that)
+      - Final outputs follow project conventions (not hidden in dot-directories, descriptive names, appropriate use of subdirectories)
+
+      ### 4. Step Instructions Match job.yml
+      - Every step defined in job.yml has a corresponding instruction file
+      - Step instruction content aligns with the step's described purpose
+      - Instructions reference the correct input and output filenames from job.yml
+      - Instructions do not duplicate content already in `common_job_info_provided_to_all_steps_at_runtime`
+      - If there is duplicated content amongst the instruction files, it should be moved to `common_job_info_provided_to_all_steps_at_runtime` and removed from the instruction files
+      - If there is content that is needed in multiple steps but not all, it should be moved to its own file and referenced in the steps
+
+      ### 5. Quality Reviews
+      - Steps with complex or final outputs have reviews defined
+      - `run_each` values reference valid output names or `step`
+      - Quality criteria are statements of expected state, not questions
+      - `additional_review_guidance` is used when reviewers need context beyond the step's own output files (e.g., cross-referencing prior step outputs)
+      - Steps with no meaningful quality checks use `reviews: []`
+
+      ### 6. Step Instruction Quality
+      - Each instruction file has clear sections: Objective, Task/Process,
+        Output Format, and Quality Criteria
+      - Instructions are specific and actionable, not generic placeholders
+      - Output format sections show what good output looks like (examples or
+        templates)
+      - If the step gathers user input, instructions mention using structured
+        questions (e.g., the AskUserQuestion tool)
+      - Instructions explain how to use file inputs from prior steps
+
+      ## Output Format
+
+      - PASS: The job definition and step instructions are coherent and
+        well-structured.
+      - FAIL: List each issue with the specific file, the problem, and a
+        suggested fix.
+    additional_context:
+      unchanged_matching_files: true

--- a/src/deepwork/standard_jobs/record/.deepreview
+++ b/src/deepwork/standard_jobs/record/.deepreview
@@ -74,3 +74,49 @@ job_definition_review:
         suggested fix.
     additional_context:
       unchanged_matching_files: true
+
+record_step_requirements:
+  description: "Verify step instruction files satisfy JOBS-REQ-011 judgment-based requirements."
+  match:
+    include:
+      - "steps/*.md"
+  review:
+    strategy: each_file
+    instructions: |
+      Review this step instruction file against the JOBS-REQ-011 requirements for the
+      record standard job. Each step has specific behavioral requirements that the
+      instruction prose must convey.
+
+      ## Requirements by step
+
+      ### steps/observe.md
+      - JOBS-REQ-011.2.3: MUST instruct the agent to start immediately without asking upfront questions.
+        Look for explicit language like "start instantly" or "do NOT ask upfront questions."
+      - JOBS-REQ-011.2.4: MUST instruct the agent to use AskUserQuestion to solicit reasoning
+        when the user takes actions whose purpose is unclear. Look for mention of AskUserQuestion
+        and guidance about when to ask vs. when not to.
+
+      ### steps/document.md
+      - JOBS-REQ-011.3.3: MUST instruct the agent to synthesize the process from conversation
+        history. Look for instructions about reflecting on the conversation or using context.
+      - JOBS-REQ-011.3.4: MUST instruct the agent to ask the user to confirm: the process
+        purpose, a name for the process, and which inputs are variable vs. fixed. All three
+        clarification topics must be present.
+
+      ### steps/reflect.md
+      - JOBS-REQ-011.4.3: The reflection MUST identify stumbling blocks with mitigation
+        strategies and efficiency improvements with expected benefits. Look for instructions
+        covering both stumbling blocks and efficiency improvements.
+
+      ### steps/generate_job.md
+      - JOBS-REQ-011.5.3: MUST defer to the deepwork_jobs/new_job workflow as a nested
+        workflow. Look for instructions to call start_workflow with deepwork_jobs/new_job.
+      - JOBS-REQ-011.5.4: MUST use the process document and reflection to inform the nested
+        workflow rather than starting from scratch.
+
+      ## Output Format
+
+      For each requirement, state PASS or FAIL with a brief explanation.
+      If any requirement fails, the overall review is FAIL.
+    additional_context:
+      unchanged_matching_files: true

--- a/src/deepwork/standard_jobs/record/.deepreview
+++ b/src/deepwork/standard_jobs/record/.deepreview
@@ -11,13 +11,7 @@ job_definition_review:
       (steps/*.md) holistically. Check that they form a coherent, well-structured
       workflow that an AI agent can execute reliably.
 
-      ## Reference Material
-
-      For reference on correct job structure and best practices, read the following files from your plugin:
-      - `job.yml.template` — canonical job.yml structure with all supported fields
-      - `job.yml.example` — a complete working example (competitive research job)
-      - `step_instruction.md.template` — expected structure for step instruction files
-      - `research_report_job_best_practices.md` — design patterns for report-type jobs
+      When reviewing, apply DeepWork job and step-instruction best practices: a canonical `job.yml` structure with all supported fields, clear example workflows, well-structured step instruction files, and sensible design patterns for report-type jobs. Base your review only on the provided `job.yml` and `steps/*.md` files; do not assume access to any additional reference files.
 
       ## What to Check
 
@@ -98,10 +92,13 @@ record_step_requirements:
 
       ### steps/document.md
       - JOBS-REQ-011.3.3: MUST instruct the agent to synthesize the process from conversation
-        history. Look for instructions about reflecting on the conversation or using context.
-      - JOBS-REQ-011.3.4: MUST instruct the agent to ask the user to confirm: the process
-        purpose, a name for the process, and which inputs are variable vs. fixed. All three
-        clarification topics must be present.
+        history, and to read the session transcript (via CLAUDE_CODE_SESSION_ID glob) when
+        compaction has occurred. Look for instructions about reflecting on the conversation
+        AND a fallback to reading transcript files.
+      - JOBS-REQ-011.3.4: MUST instruct the agent to ask the user to clarify remaining reasoning gaps
+        and, only when the facts were not explicitly stated or clearly demonstrated during observation,
+        confirm: the process purpose, a name for the process, and which inputs are variable vs. fixed.
+        All three confirmation topics must be present, conditioned on what was observable.
 
       ### steps/reflect.md
       - JOBS-REQ-011.4.3: The reflection MUST identify stumbling blocks with mitigation

--- a/src/deepwork/standard_jobs/record/job.yml
+++ b/src/deepwork/standard_jobs/record/job.yml
@@ -1,0 +1,112 @@
+name: record
+version: "1.0.0"
+summary: "Record a user's process with AI assistance, then generate a reusable DeepWork job from it"
+common_job_info_provided_to_all_steps_at_runtime: |
+  A meta-workflow for capturing and automating processes. The agent actively assists the
+  user through their task while recording every step, tool used, decision made, and
+  input/output produced. After recording, the agent synthesizes observations into a
+  structured process document, reflects on efficiency improvements and stumbling blocks,
+  and then launches the deepwork_jobs/new_job workflow to generate a complete DeepWork
+  job definition.
+
+  The goal is to turn a one-off manual process into a repeatable, reviewable workflow
+  that any AI agent can execute.
+
+  Key principles:
+  - Record everything: tools, commands, files read/written, decisions, and rationale
+  - Be helpful: actively assist the user rather than passively watching
+  - Capture context: note why steps are done, not just what is done
+  - Identify patterns: look for repeated actions that could be templated
+
+workflows:
+  - name: record
+    summary: "Record a process end-to-end and generate a DeepWork job from it"
+    steps:
+      - observe
+      - document
+      - reflect
+      - generate_job
+
+steps:
+  - id: observe
+    name: "Observe and assist"
+    description: "Help the user complete their process while recording every action, tool, and decision"
+    instructions_file: steps/observe.md
+    inputs:
+      - name: process_name
+        description: "Short name for the process being recorded (lowercase, underscores)"
+      - name: process_description
+        description: "What is the process you want to record? Describe the task and its goal."
+    outputs:
+      observation_log.md:
+        type: file
+        description: "Chronological log of every action, tool, decision, and outcome observed during the process"
+        required: true
+    dependencies: []
+    reviews: []
+
+  - id: document
+    name: "Document the process"
+    description: "Synthesize the observation log into a structured process document"
+    instructions_file: steps/document.md
+    inputs:
+      - file: observation_log.md
+        from_step: observe
+    outputs:
+      process_document.md:
+        type: file
+        description: "Structured process document with all tools, steps, inputs, outputs, and decision points"
+        required: true
+    dependencies:
+      - observe
+    reviews:
+      - run_each: process_document.md
+        additional_review_guidance: "Read the observation_log.md from the observe step to verify completeness."
+        quality_criteria:
+          "Complete Coverage": "Every action and tool from the observation log is represented in the process document."
+          "Clear Structure": "Steps are logically ordered with clear inputs, outputs, and decision points for each."
+          "Tool Inventory": "All tools, commands, and external resources used are listed with their purpose."
+
+  - id: reflect
+    name: "Reflect on the process"
+    description: "Analyze the process for efficiency improvements, stumbling blocks, and automation opportunities"
+    instructions_file: steps/reflect.md
+    inputs:
+      - file: observation_log.md
+        from_step: observe
+      - file: process_document.md
+        from_step: document
+    outputs:
+      reflection.md:
+        type: file
+        description: "Analysis of efficiency improvements, stumbling blocks, and recommendations for the automated workflow"
+        required: true
+    dependencies:
+      - observe
+      - document
+    reviews:
+      - run_each: reflection.md
+        additional_review_guidance: "Read the process_document.md and observation_log.md to verify the reflection is grounded in what actually happened."
+        quality_criteria:
+          "Actionable Improvements": "Each improvement is specific and explains how to implement it in the automated workflow."
+          "Stumbling Blocks Identified": "Pain points and failure-prone steps from the recording are identified with mitigation strategies."
+          "Grounded in Evidence": "Insights reference specific observations from the recording, not generic advice."
+
+  - id: generate_job
+    name: "Generate DeepWork job"
+    description: "Launch the deepwork_jobs/new_job workflow using the process document and reflection as context"
+    instructions_file: steps/generate_job.md
+    inputs:
+      - file: process_document.md
+        from_step: document
+      - file: reflection.md
+        from_step: reflect
+    outputs:
+      job_created.md:
+        type: file
+        description: "Confirmation of the generated job with its location and summary"
+        required: true
+    dependencies:
+      - document
+      - reflect
+    reviews: []

--- a/src/deepwork/standard_jobs/record/job.yml
+++ b/src/deepwork/standard_jobs/record/job.yml
@@ -1,20 +1,19 @@
 name: record
-version: "1.0.0"
+version: "1.1.0"
 summary: "Record a user's process with AI assistance, then generate a reusable DeepWork job from it"
 common_job_info_provided_to_all_steps_at_runtime: |
   A meta-workflow for capturing and automating processes. The agent actively assists the
-  user through their task while recording every step, tool used, decision made, and
-  input/output produced. After recording, the agent synthesizes observations into a
-  structured process document, reflects on efficiency improvements and stumbling blocks,
-  and then launches the deepwork_jobs/new_job workflow to generate a complete DeepWork
-  job definition.
+  user through their task while mentally recording every step, tool used, decision made,
+  and input/output produced. The conversation itself is the record — no log files are
+  written during observation.
 
-  The goal is to turn a one-off manual process into a repeatable, reviewable workflow
-  that any AI agent can execute.
+  After recording, the agent synthesizes observations into a structured process document,
+  reflects on efficiency improvements and stumbling blocks, and launches the
+  deepwork_jobs/new_job workflow to generate a complete DeepWork job definition.
 
   Key principles:
-  - Record everything: tools, commands, files read/written, decisions, and rationale
-  - Be helpful: actively assist the user rather than passively watching
+  - Start instantly: no upfront questions, just help the user
+  - Understand why: ask about reasoning when actions are unclear
   - Capture context: note why steps are done, not just what is done
   - Identify patterns: look for repeated actions that could be templated
 
@@ -30,50 +29,37 @@ workflows:
 steps:
   - id: observe
     name: "Observe and assist"
-    description: "Help the user complete their process while recording every action, tool, and decision"
+    description: "Observe the user working in real time, asking clarifying questions when their reasoning is unclear"
     instructions_file: steps/observe.md
-    inputs:
-      - name: process_name
-        description: "Short name for the process being recorded (lowercase, underscores)"
-      - name: process_description
-        description: "What is the process you want to record? Describe the task and its goal."
-    outputs:
-      observation_log.md:
-        type: file
-        description: "Chronological log of every action, tool, decision, and outcome observed during the process"
-        required: true
+    inputs: []
+    outputs: {}
     dependencies: []
     reviews: []
 
   - id: document
     name: "Document the process"
-    description: "Synthesize the observation log into a structured process document"
+    description: "Synthesize observations from the conversation into a structured process document"
     instructions_file: steps/document.md
-    inputs:
-      - file: observation_log.md
-        from_step: observe
+    inputs: []
     outputs:
       process_document.md:
         type: file
-        description: "Structured process document with all tools, steps, inputs, outputs, and decision points"
+        description: "Structured process document with name, purpose, tools, steps, variable/fixed inputs, and decision points"
         required: true
     dependencies:
       - observe
     reviews:
       - run_each: process_document.md
-        additional_review_guidance: "Read the observation_log.md from the observe step to verify completeness."
         quality_criteria:
-          "Complete Coverage": "Every action and tool from the observation log is represented in the process document."
-          "Clear Structure": "Steps are logically ordered with clear inputs, outputs, and decision points for each."
-          "Tool Inventory": "All tools, commands, and external resources used are listed with their purpose."
+          "Complete Coverage": "All observed actions and tools are represented in the process document."
+          "Clear Structure": "Steps are logically ordered with clear inputs, outputs, and decision points."
+          "User Clarification Incorporated": "The document includes the process name, purpose, and variable vs. fixed inputs as confirmed by the user."
 
   - id: reflect
     name: "Reflect on the process"
     description: "Analyze the process for efficiency improvements, stumbling blocks, and automation opportunities"
     instructions_file: steps/reflect.md
     inputs:
-      - file: observation_log.md
-        from_step: observe
       - file: process_document.md
         from_step: document
     outputs:
@@ -82,15 +68,14 @@ steps:
         description: "Analysis of efficiency improvements, stumbling blocks, and recommendations for the automated workflow"
         required: true
     dependencies:
-      - observe
       - document
     reviews:
       - run_each: reflection.md
-        additional_review_guidance: "Read the process_document.md and observation_log.md to verify the reflection is grounded in what actually happened."
+        additional_review_guidance: "Read the process_document.md to verify the reflection is grounded in what was documented."
         quality_criteria:
           "Actionable Improvements": "Each improvement is specific and explains how to implement it in the automated workflow."
-          "Stumbling Blocks Identified": "Pain points and failure-prone steps from the recording are identified with mitigation strategies."
-          "Grounded in Evidence": "Insights reference specific observations from the recording, not generic advice."
+          "Stumbling Blocks Identified": "Pain points and failure-prone steps are identified with mitigation strategies."
+          "Grounded in Evidence": "Insights reference specific details from the process document, not generic advice."
 
   - id: generate_job
     name: "Generate DeepWork job"

--- a/src/deepwork/standard_jobs/record/steps/document.md
+++ b/src/deepwork/standard_jobs/record/steps/document.md
@@ -2,85 +2,76 @@
 
 ## Objective
 
-Synthesize the raw observation log into a structured process document that captures all tools, steps, inputs, outputs, and decision points in a form suitable for automation.
+Synthesize everything observed during the conversation into a structured process document, then confirm key details with the user.
 
 ## Task
 
-Read the observation log from the observe step and transform it into a clean, structured process document. This document will be used both as a standalone reference and as input for generating a DeepWork job definition.
+### 1. Draft from memory
 
-### Process
+Reflect on the entire conversation from the observe step. Write a first draft of the process document capturing every action, tool, decision, and outcome you observed.
 
-1. **Read the observation log**
-   - Identify all distinct steps in the process
-   - Note the tools and commands used at each step
-   - Map the data flow: what outputs from one step feed into the next
+If the conversation feels incomplete (e.g., compaction happened and you lost context), tell the user what you remember and ask them to fill in the gaps before drafting.
 
-2. **Normalize and structure**
-   - Group related actions into logical steps (the raw log may have finer granularity than needed)
-   - Name each step with a clear, descriptive title
-   - Identify which steps require user input vs. which can run autonomously
-   - Document decision points and branching logic
+### 2. Clarify with the user
 
-3. **Catalog tools and resources**
-   - List every tool, command, API, or service used
-   - Note the purpose of each tool in the context of this process
-   - Flag any tools that require special access or configuration
+After drafting, use AskUserQuestion to confirm three things (ask all at once if possible):
 
-4. **Define inputs and outputs for each step**
-   - What information enters the step (user input, file from prior step, external data)
-   - What the step produces (files, state changes, API calls)
-   - What format each input/output is in
+1. **Purpose**: "What is the goal of this process? What does it accomplish?"
+2. **Name**: "What would you call this process?" (suggest a name based on what you observed)
+3. **Variable vs. fixed inputs**: "Which inputs change every time you run this, and which stay the same?"
 
-## Output Format
+### 3. Amend the document
+
+Update the draft to incorporate the user's answers. Ensure the process name, purpose, and input classification are reflected throughout.
+
+## Output format
 
 ### process_document.md
 
-A structured process document ready to inform job creation.
-
-**Structure**:
 ```markdown
 # Process Document: [process_name]
 
-## Summary
-[1-2 sentence description of what this process accomplishes and who it serves]
+## Purpose
+[What this process accomplishes and who it serves, as confirmed by the user]
+
+## Inputs
+### Variable (change each invocation)
+- [input]: [description]
+
+### Fixed (same every time)
+- [input]: [description]
 
 ## Tool Inventory
 | Tool | Purpose | Required Access |
 |------|---------|-----------------|
-| [tool name] | [what it's used for] | [any setup needed] |
+| [tool] | [what it's used for] | [setup needed] |
 
 ## Process Steps
 
 ### Step 1: [Step name]
 - **Purpose**: [What this step accomplishes]
 - **Type**: [User-interactive / Autonomous / Semi-autonomous]
-- **Inputs**:
-  - [Input name]: [description] (source: [user / prior step / external])
+- **Inputs**: [What enters this step]
 - **Actions**:
-  1. [Action description]
-  2. [Action description]
-- **Outputs**:
-  - [Output name]: [description] (format: [markdown / JSON / etc.])
-- **Decision points**: [Any branching logic or conditional actions]
+  1. [Action]
+  2. [Action]
+- **Outputs**: [What this step produces]
+- **Decision points**: [Any branching logic]
 
 [Repeat for each step]
 
 ## Data Flow
-[Description or diagram of how data moves between steps]
+[How outputs from one step feed into the next]
 
 ## External Dependencies
-- [Service, API, or resource this process depends on]
-- [Access requirements or credentials needed]
+- [Services, APIs, credentials, or resources required]
+
+## Implicit Knowledge
+- [Things the user relied on that an AI agent would need to be told]
 ```
 
-## Quality Criteria
+## Quality criteria
 
-- Every action and tool from the observation log is represented in the process document
-- Steps are logically ordered with clear inputs, outputs, and decision points for each
-- All tools, commands, and external resources used are listed with their purpose
-- The document distinguishes between user-interactive and autonomous steps
-- Data flow between steps is explicit — no implicit handoffs
-
-## Context
-
-This document serves as the blueprint for the generated DeepWork job. The clearer and more structured it is, the better the generated job will be. Focus on making the process reproducible by someone (or an AI agent) who has never seen it before.
+- All observed actions and tools are represented
+- Steps are logically ordered with clear inputs, outputs, and decision points
+- The document includes the process name, purpose, and variable vs. fixed inputs as confirmed by the user

--- a/src/deepwork/standard_jobs/record/steps/document.md
+++ b/src/deepwork/standard_jobs/record/steps/document.md
@@ -6,19 +6,21 @@ Synthesize everything observed during the conversation into a structured process
 
 ## Task
 
-### 1. Draft from memory
+### 1. Reconstruct the process
 
-Reflect on the entire conversation from the observe step. Write a first draft of the process document capturing every action, tool, decision, and outcome you observed.
+Reflect on the entire conversation from the observe step. If any compaction has happened, use `CLAUDE_CODE_SESSION_ID` to locate and read the session transcript (glob `~/.claude/projects/**/sessions/<session_id>/*.jsonl`) to recover what was lost before drafting.
 
-If the conversation feels incomplete (e.g., compaction happened and you lost context), tell the user what you remember and ask them to fill in the gaps before drafting.
+Write a first draft of the process document capturing every action, tool, decision, and outcome you observed.
 
 ### 2. Clarify with the user
 
-After drafting, use AskUserQuestion to confirm three things (ask all at once if possible):
+After drafting, use AskUserQuestion to address two things (combine into one question where possible):
 
-1. **Purpose**: "What is the goal of this process? What does it accomplish?"
-2. **Name**: "What would you call this process?" (suggest a name based on what you observed)
-3. **Variable vs. fixed inputs**: "Which inputs change every time you run this, and which stay the same?"
+1. **Remaining reasoning gaps**: Ask about any actions whose purpose you are still uncertain about after reviewing the conversation or transcript.
+2. **Key facts** — only ask about items where you cannot answer from what was explicitly stated or clearly demonstrated during the observation:
+   - **Purpose**: What is the goal of this process? What does it accomplish?
+   - **Name**: What would you call this process? (suggest a name based on what you observed)
+   - **Variable vs. fixed inputs**: Which inputs change every time you run this, and which stay the same?
 
 ### 3. Amend the document
 

--- a/src/deepwork/standard_jobs/record/steps/document.md
+++ b/src/deepwork/standard_jobs/record/steps/document.md
@@ -1,0 +1,86 @@
+# Document the process
+
+## Objective
+
+Synthesize the raw observation log into a structured process document that captures all tools, steps, inputs, outputs, and decision points in a form suitable for automation.
+
+## Task
+
+Read the observation log from the observe step and transform it into a clean, structured process document. This document will be used both as a standalone reference and as input for generating a DeepWork job definition.
+
+### Process
+
+1. **Read the observation log**
+   - Identify all distinct steps in the process
+   - Note the tools and commands used at each step
+   - Map the data flow: what outputs from one step feed into the next
+
+2. **Normalize and structure**
+   - Group related actions into logical steps (the raw log may have finer granularity than needed)
+   - Name each step with a clear, descriptive title
+   - Identify which steps require user input vs. which can run autonomously
+   - Document decision points and branching logic
+
+3. **Catalog tools and resources**
+   - List every tool, command, API, or service used
+   - Note the purpose of each tool in the context of this process
+   - Flag any tools that require special access or configuration
+
+4. **Define inputs and outputs for each step**
+   - What information enters the step (user input, file from prior step, external data)
+   - What the step produces (files, state changes, API calls)
+   - What format each input/output is in
+
+## Output Format
+
+### process_document.md
+
+A structured process document ready to inform job creation.
+
+**Structure**:
+```markdown
+# Process Document: [process_name]
+
+## Summary
+[1-2 sentence description of what this process accomplishes and who it serves]
+
+## Tool Inventory
+| Tool | Purpose | Required Access |
+|------|---------|-----------------|
+| [tool name] | [what it's used for] | [any setup needed] |
+
+## Process Steps
+
+### Step 1: [Step name]
+- **Purpose**: [What this step accomplishes]
+- **Type**: [User-interactive / Autonomous / Semi-autonomous]
+- **Inputs**:
+  - [Input name]: [description] (source: [user / prior step / external])
+- **Actions**:
+  1. [Action description]
+  2. [Action description]
+- **Outputs**:
+  - [Output name]: [description] (format: [markdown / JSON / etc.])
+- **Decision points**: [Any branching logic or conditional actions]
+
+[Repeat for each step]
+
+## Data Flow
+[Description or diagram of how data moves between steps]
+
+## External Dependencies
+- [Service, API, or resource this process depends on]
+- [Access requirements or credentials needed]
+```
+
+## Quality Criteria
+
+- Every action and tool from the observation log is represented in the process document
+- Steps are logically ordered with clear inputs, outputs, and decision points for each
+- All tools, commands, and external resources used are listed with their purpose
+- The document distinguishes between user-interactive and autonomous steps
+- Data flow between steps is explicit — no implicit handoffs
+
+## Context
+
+This document serves as the blueprint for the generated DeepWork job. The clearer and more structured it is, the better the generated job will be. Focus on making the process reproducible by someone (or an AI agent) who has never seen it before.

--- a/src/deepwork/standard_jobs/record/steps/generate_job.md
+++ b/src/deepwork/standard_jobs/record/steps/generate_job.md
@@ -1,0 +1,81 @@
+# Generate DeepWork job
+
+## Objective
+
+Launch the `deepwork_jobs/new_job` workflow to create a complete DeepWork job definition, using the process document and reflection as context to drive the definition.
+
+## Task
+
+Start the existing `deepwork_jobs/new_job` workflow as a nested workflow. Use the process document and reflection to provide informed answers during the job definition process rather than starting from scratch.
+
+### Process
+
+1. **Read the inputs**
+   - Read `process_document.md` to understand the steps, tools, inputs, and outputs
+   - Read `reflection.md` to understand improvements and stumbling blocks to incorporate
+
+2. **Prepare the goal**
+   - Synthesize a clear goal statement from the process document summary and the reflection recommendations
+   - The goal should describe what the automated job will do, incorporating the efficiency improvements
+
+3. **Start the nested workflow**
+   - Call `start_workflow` with:
+     - `job_name`: `"deepwork_jobs"`
+     - `workflow_name`: `"new_job"`
+     - `goal`: the synthesized goal from above
+   - Follow the `new_job` workflow's instructions as they come
+
+4. **Use the process document to drive definition**
+   - When the `new_job` define step asks about the workflow's purpose, draw from the process document summary
+   - When asked about steps, map from the process document's step list — but incorporate reflection recommendations (reordering, parallelization, new validation steps)
+   - When asked about inputs/outputs, use the process document's data flow
+   - When asked about quality reviews, use the stumbling blocks from the reflection to define what to check
+   - Encode implicit knowledge from the reflection into the `common_job_info_provided_to_all_steps_at_runtime`
+
+5. **Confirm with the user**
+   - Before finalizing, present the mapping: which recorded steps became which job steps, and what changes were made based on the reflection
+   - Ask the user if the generated job captures their intent
+
+6. **Record what was created**
+   - After the nested workflow completes, write a brief confirmation file noting the job name and location
+
+## Output Format
+
+### job_created.md
+
+A brief confirmation of what was generated.
+
+**Structure**:
+```markdown
+# Job Created: [new_job_name]
+
+## Location
+`.deepwork/jobs/[new_job_name]/`
+
+## Summary
+[One-line summary of the generated job]
+
+## Steps
+1. [step_name] - [brief description]
+2. [step_name] - [brief description]
+
+## Changes from Recording
+- [What was changed from the raw recording based on reflection insights]
+
+## Next Steps
+- Review the generated job.yml and step instruction files
+- Run the job with `/deepwork [new_job_name]` to test it
+- Use `/deepwork learn` after testing to refine the instructions
+```
+
+## Quality Criteria
+
+- The nested `deepwork_jobs/new_job` workflow is started (not bypassed)
+- The process document and reflection are used to inform the job definition
+- Reflection improvements are incorporated into the job structure and step instructions
+- The user confirms the generated job before finalizing
+- A confirmation file documents what was created and what changed from the recording
+
+## Context
+
+This step bridges recording and automation. By deferring to the existing `new_job` workflow, we get the full quality gate process for job creation while using the recorded process and reflection as rich input context. The result should be a job that is better than a literal replay of the recording — it should incorporate the efficiency improvements and stumbling block mitigations from the reflection.

--- a/src/deepwork/standard_jobs/record/steps/observe.md
+++ b/src/deepwork/standard_jobs/record/steps/observe.md
@@ -2,96 +2,41 @@
 
 ## Objective
 
-Help the user complete their process while recording every action, tool, decision, and outcome in a structured observation log.
+Help the user complete their process while mentally recording every action, tool, decision, and outcome. Start immediately — do NOT ask any upfront questions about the process.
 
 ## Task
 
-You are both an assistant and a recorder. The user will walk you through a process they want to automate. Your job is to actively help them complete the task while simultaneously documenting everything that happens.
+You are a participant-observer. The user is about to perform a process they want to automate. Your job is to help them do it while paying close attention to everything that happens.
 
-### Process
+### Behavior
 
-1. **Understand the process**
-   - Read the `process_name` and `process_description` inputs
-   - Ask structured questions to clarify the starting conditions: What triggers this process? What do they need before starting? What does "done" look like?
+- **Start instantly.** Do not ask "what are we doing?" or "what is this process?" — just follow the user's lead and help.
+- **Help actively.** When the user asks you to do something, do it. You are an assistant, not a passive watcher.
+- **Ask about reasoning, not facts.** You MUST use AskUserQuestion when the user takes an action (not information gathering) and you do not understand WHY they are doing it. Your goal is to capture the rationale behind decisions, not just the actions.
 
-2. **Assist and record**
-   - Help the user complete each action they describe
-   - After each action, record it in your running log with:
-     - What was done (the action)
-     - What tool or command was used
-     - What inputs were provided
-     - What the outcome was
-     - Any decisions made and their rationale
-   - If the user skips over details, ask what they did and why
+### When to ask
 
-3. **Capture context throughout**
-   - Note when the user hesitates or backtracks — these are potential stumbling blocks
-   - Record any workarounds or "I usually have to do this because..." moments
-   - Note external dependencies (APIs, services, other people, manual steps)
-   - Track the order of operations and any branching logic ("if X, then I do Y")
+- The user makes a choice between alternatives and the rationale is not obvious
+- The user performs a step that seems like a workaround or unusual approach
+- The user skips something you would have expected them to do
+- There is a decision point with branching logic
 
-4. **Confirm completion**
-   - When the user indicates they are done, review the log with them
-   - Ask if any steps were skipped or forgotten
-   - Confirm the final output/deliverable of the process
+### When NOT to ask
 
-### Important guidelines
+- The user is gathering information or reading files — let them work
+- The action's purpose is clear from context
+- You just asked a question — do not rapid-fire questions
 
-- Do NOT try to optimize the process while recording — capture what the user actually does, not what they should do
-- Ask clarifying questions when actions are ambiguous, but do not interrupt the flow unnecessarily
-- If the user asks you to perform an action, do it AND record it
-- Capture exact tool names, commands, file paths, and URLs when possible
+### What to track mentally
 
-## Output Format
+Keep a running mental model of:
+- Actions taken and tools/commands used
+- Decisions made and their rationale (especially when you asked)
+- Points where the user hesitated, backtracked, or expressed frustration
+- Implicit knowledge the user relied on (things they just "knew")
+- Branching logic ("if X then I do Y, otherwise Z")
+- External dependencies (APIs, services, credentials, other people)
 
-### observation_log.md
+### Completion
 
-A chronological log of the recorded process.
-
-**Structure**:
-```markdown
-# Observation Log: [process_name]
-
-## Process Overview
-- **Name**: [process_name]
-- **Description**: [process_description]
-- **Date recorded**: [current date]
-- **Trigger**: [What initiates this process]
-- **Completion criteria**: [How the user knows the process is done]
-
-## Prerequisites
-- [Tool, access, or resource needed before starting]
-- [Another prerequisite]
-
-## Observation Log
-
-### Step 1: [Action description]
-- **Action**: [What was done]
-- **Tool/Command**: [Tool or command used, if any]
-- **Inputs**: [What was provided]
-- **Output**: [What resulted]
-- **Decision**: [Any choice made and why]
-- **Notes**: [Hesitations, workarounds, or context]
-
-### Step 2: [Action description]
-[Same structure repeated for each observed action]
-
-## Final Deliverable
-- **What was produced**: [Description of the end result]
-- **Where it lives**: [File path, URL, or location]
-
-## Raw Notes
-[Any additional observations about the process that don't fit neatly into steps — e.g., things the user mentioned in passing, implicit knowledge they relied on, or patterns noticed]
-```
-
-## Quality Criteria
-
-- Every action the user took is recorded with tool, input, and output
-- Decisions and their rationale are captured, not just actions
-- The log is chronological and easy to follow
-- Hesitations, workarounds, and pain points are noted
-- Prerequisites and completion criteria are documented
-
-## Context
-
-This is the foundation step. The quality of everything downstream — the process document, the reflection, and the generated job — depends on how thoroughly this step captures what actually happened. Err on the side of recording too much rather than too little.
+When the user signals they are done (e.g., "that's it," "done," "finished"), call `finished_step` with empty outputs `{}`. Do not write any files during this step.

--- a/src/deepwork/standard_jobs/record/steps/observe.md
+++ b/src/deepwork/standard_jobs/record/steps/observe.md
@@ -1,0 +1,97 @@
+# Observe and assist
+
+## Objective
+
+Help the user complete their process while recording every action, tool, decision, and outcome in a structured observation log.
+
+## Task
+
+You are both an assistant and a recorder. The user will walk you through a process they want to automate. Your job is to actively help them complete the task while simultaneously documenting everything that happens.
+
+### Process
+
+1. **Understand the process**
+   - Read the `process_name` and `process_description` inputs
+   - Ask structured questions to clarify the starting conditions: What triggers this process? What do they need before starting? What does "done" look like?
+
+2. **Assist and record**
+   - Help the user complete each action they describe
+   - After each action, record it in your running log with:
+     - What was done (the action)
+     - What tool or command was used
+     - What inputs were provided
+     - What the outcome was
+     - Any decisions made and their rationale
+   - If the user skips over details, ask what they did and why
+
+3. **Capture context throughout**
+   - Note when the user hesitates or backtracks — these are potential stumbling blocks
+   - Record any workarounds or "I usually have to do this because..." moments
+   - Note external dependencies (APIs, services, other people, manual steps)
+   - Track the order of operations and any branching logic ("if X, then I do Y")
+
+4. **Confirm completion**
+   - When the user indicates they are done, review the log with them
+   - Ask if any steps were skipped or forgotten
+   - Confirm the final output/deliverable of the process
+
+### Important guidelines
+
+- Do NOT try to optimize the process while recording — capture what the user actually does, not what they should do
+- Ask clarifying questions when actions are ambiguous, but do not interrupt the flow unnecessarily
+- If the user asks you to perform an action, do it AND record it
+- Capture exact tool names, commands, file paths, and URLs when possible
+
+## Output Format
+
+### observation_log.md
+
+A chronological log of the recorded process.
+
+**Structure**:
+```markdown
+# Observation Log: [process_name]
+
+## Process Overview
+- **Name**: [process_name]
+- **Description**: [process_description]
+- **Date recorded**: [current date]
+- **Trigger**: [What initiates this process]
+- **Completion criteria**: [How the user knows the process is done]
+
+## Prerequisites
+- [Tool, access, or resource needed before starting]
+- [Another prerequisite]
+
+## Observation Log
+
+### Step 1: [Action description]
+- **Action**: [What was done]
+- **Tool/Command**: [Tool or command used, if any]
+- **Inputs**: [What was provided]
+- **Output**: [What resulted]
+- **Decision**: [Any choice made and why]
+- **Notes**: [Hesitations, workarounds, or context]
+
+### Step 2: [Action description]
+[Same structure repeated for each observed action]
+
+## Final Deliverable
+- **What was produced**: [Description of the end result]
+- **Where it lives**: [File path, URL, or location]
+
+## Raw Notes
+[Any additional observations about the process that don't fit neatly into steps — e.g., things the user mentioned in passing, implicit knowledge they relied on, or patterns noticed]
+```
+
+## Quality Criteria
+
+- Every action the user took is recorded with tool, input, and output
+- Decisions and their rationale are captured, not just actions
+- The log is chronological and easy to follow
+- Hesitations, workarounds, and pain points are noted
+- Prerequisites and completion criteria are documented
+
+## Context
+
+This is the foundation step. The quality of everything downstream — the process document, the reflection, and the generated job — depends on how thoroughly this step captures what actually happened. Err on the side of recording too much rather than too little.

--- a/src/deepwork/standard_jobs/record/steps/reflect.md
+++ b/src/deepwork/standard_jobs/record/steps/reflect.md
@@ -1,0 +1,93 @@
+# Reflect on the process
+
+## Objective
+
+Analyze the recorded process to identify efficiency improvements, stumbling blocks, and recommendations that should be incorporated into the automated workflow.
+
+## Task
+
+Read both the observation log and the process document, then produce a reflection that identifies what went well, what was painful, and what could be improved when this process runs as an automated workflow.
+
+### Process
+
+1. **Review the raw observations**
+   - Re-read the observation log, paying attention to:
+     - Places where the user hesitated or backtracked
+     - Workarounds or manual steps that felt tedious
+     - Steps that took disproportionately long
+     - Implicit knowledge the user relied on
+
+2. **Identify stumbling blocks**
+   - What steps were error-prone or confusing?
+   - Where did the user need to retry or course-correct?
+   - What external dependencies caused delays or friction?
+   - What implicit knowledge would an AI agent lack?
+
+3. **Identify efficiency improvements**
+   - Which steps could be parallelized?
+   - Where could templates or defaults reduce manual input?
+   - Are there steps that could be combined or eliminated?
+   - Could any manual lookups be automated with tools?
+
+4. **Formulate recommendations**
+   - For each improvement, describe the concrete change to make in the automated workflow
+   - For each stumbling block, describe how to mitigate it (better instructions, validation, fallback)
+   - Prioritize by impact: what changes would save the most time or prevent the most errors?
+
+## Output Format
+
+### reflection.md
+
+An analysis with actionable recommendations for the automated workflow.
+
+**Structure**:
+```markdown
+# Process Reflection: [process_name]
+
+## Summary
+[1-2 sentences on the overall quality of the process and the biggest opportunities]
+
+## Stumbling Blocks
+
+### 1. [Block title]
+- **What happened**: [Describe the specific issue observed]
+- **Impact**: [How it affected the process — time lost, errors, rework]
+- **Mitigation**: [How to prevent or handle this in the automated workflow]
+
+[Repeat for each stumbling block]
+
+## Efficiency Improvements
+
+### 1. [Improvement title]
+- **Current state**: [How the step works now]
+- **Proposed change**: [Specific change to make]
+- **Expected benefit**: [Time saved, errors prevented, or quality improved]
+
+[Repeat for each improvement]
+
+## Recommendations for Automated Workflow
+
+### Step-level recommendations
+| Step | Recommendation | Priority |
+|------|---------------|----------|
+| [step name] | [what to change] | [high/medium/low] |
+
+### Workflow-level recommendations
+- [Any structural changes — reordering, parallelization, new steps, removed steps]
+
+## Implicit Knowledge to Encode
+- [Things the user knew that an AI agent would need to be told explicitly]
+- [Domain conventions, naming patterns, or unwritten rules]
+```
+
+## Quality Criteria
+
+- Each improvement is specific and explains how to implement it in the automated workflow
+- Pain points and failure-prone steps from the recording are identified with mitigation strategies
+- Insights reference specific observations from the recording, not generic advice
+- Implicit knowledge that an AI agent would need is surfaced and documented
+- Recommendations are prioritized by impact
+
+## Context
+
+This reflection is the bridge between "what happened" and "what the automated workflow should do." The generated DeepWork job should be better than the raw recording — incorporating the lessons learned here. Focus on actionable insights that translate directly into better step instructions, validation checks, or workflow structure.

--- a/src/deepwork/standard_jobs/record/steps/reflect.md
+++ b/src/deepwork/standard_jobs/record/steps/reflect.md
@@ -2,92 +2,71 @@
 
 ## Objective
 
-Analyze the recorded process to identify efficiency improvements, stumbling blocks, and recommendations that should be incorporated into the automated workflow.
+Analyze the process document to identify efficiency improvements, stumbling blocks, and recommendations for the automated workflow.
 
 ## Task
 
-Read both the observation log and the process document, then produce a reflection that identifies what went well, what was painful, and what could be improved when this process runs as an automated workflow.
+### 1. Review the process document
 
-### Process
+Read `process_document.md` and look for:
+- Steps that were error-prone or required backtracking
+- Workarounds or manual steps that felt tedious
+- Steps that took disproportionately long
+- Implicit knowledge that an AI agent would lack
+- External dependencies that caused friction
 
-1. **Review the raw observations**
-   - Re-read the observation log, paying attention to:
-     - Places where the user hesitated or backtracked
-     - Workarounds or manual steps that felt tedious
-     - Steps that took disproportionately long
-     - Implicit knowledge the user relied on
+### 2. Identify stumbling blocks
 
-2. **Identify stumbling blocks**
-   - What steps were error-prone or confusing?
-   - Where did the user need to retry or course-correct?
-   - What external dependencies caused delays or friction?
-   - What implicit knowledge would an AI agent lack?
+For each pain point, describe what happened, its impact, and how to mitigate it in the automated workflow.
 
-3. **Identify efficiency improvements**
-   - Which steps could be parallelized?
-   - Where could templates or defaults reduce manual input?
-   - Are there steps that could be combined or eliminated?
-   - Could any manual lookups be automated with tools?
+### 3. Identify efficiency improvements
 
-4. **Formulate recommendations**
-   - For each improvement, describe the concrete change to make in the automated workflow
-   - For each stumbling block, describe how to mitigate it (better instructions, validation, fallback)
-   - Prioritize by impact: what changes would save the most time or prevent the most errors?
+Look for:
+- Steps that could be parallelized
+- Places where templates or defaults could reduce manual input
+- Steps that could be combined or eliminated
+- Manual lookups that could be automated
 
-## Output Format
+### 4. Prioritize recommendations
+
+Rank by impact: what changes would save the most time or prevent the most errors?
+
+## Output format
 
 ### reflection.md
 
-An analysis with actionable recommendations for the automated workflow.
-
-**Structure**:
 ```markdown
 # Process Reflection: [process_name]
 
 ## Summary
-[1-2 sentences on the overall quality of the process and the biggest opportunities]
+[1-2 sentences on the biggest opportunities]
 
 ## Stumbling Blocks
 
 ### 1. [Block title]
-- **What happened**: [Describe the specific issue observed]
-- **Impact**: [How it affected the process — time lost, errors, rework]
-- **Mitigation**: [How to prevent or handle this in the automated workflow]
-
-[Repeat for each stumbling block]
+- **What happened**: [Specific issue from the process document]
+- **Impact**: [Time lost, errors, rework]
+- **Mitigation**: [How to handle this in the automated workflow]
 
 ## Efficiency Improvements
 
 ### 1. [Improvement title]
 - **Current state**: [How the step works now]
-- **Proposed change**: [Specific change to make]
-- **Expected benefit**: [Time saved, errors prevented, or quality improved]
-
-[Repeat for each improvement]
+- **Proposed change**: [Specific change]
+- **Expected benefit**: [Time saved, errors prevented]
 
 ## Recommendations for Automated Workflow
 
-### Step-level recommendations
 | Step | Recommendation | Priority |
 |------|---------------|----------|
-| [step name] | [what to change] | [high/medium/low] |
-
-### Workflow-level recommendations
-- [Any structural changes — reordering, parallelization, new steps, removed steps]
+| [step] | [change] | [high/medium/low] |
 
 ## Implicit Knowledge to Encode
-- [Things the user knew that an AI agent would need to be told explicitly]
-- [Domain conventions, naming patterns, or unwritten rules]
+- [Things an AI agent would need to be told explicitly]
 ```
 
-## Quality Criteria
+## Quality criteria
 
 - Each improvement is specific and explains how to implement it in the automated workflow
-- Pain points and failure-prone steps from the recording are identified with mitigation strategies
-- Insights reference specific observations from the recording, not generic advice
-- Implicit knowledge that an AI agent would need is surfaced and documented
-- Recommendations are prioritized by impact
-
-## Context
-
-This reflection is the bridge between "what happened" and "what the automated workflow should do." The generated DeepWork job should be better than the raw recording — incorporating the lessons learned here. Focus on actionable insights that translate directly into better step instructions, validation checks, or workflow structure.
+- Pain points are identified with mitigation strategies
+- Insights reference specific details from the process document, not generic advice

--- a/tests/unit/jobs/test_record_standard_job.py
+++ b/tests/unit/jobs/test_record_standard_job.py
@@ -1,0 +1,165 @@
+"""Tests for the record standard job definition (JOBS-REQ-011)."""
+
+from pathlib import Path
+
+import pytest
+
+from deepwork.jobs.parser import parse_job_definition
+
+RECORD_JOB_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "deepwork"
+    / "standard_jobs"
+    / "record"
+)
+
+
+@pytest.fixture()
+def job():
+    """Parse the record standard job definition."""
+    return parse_job_definition(RECORD_JOB_DIR)
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.1.1).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_job_location():
+    """The record job MUST be at src/deepwork/standard_jobs/record/."""
+    assert RECORD_JOB_DIR.exists()
+    assert (RECORD_JOB_DIR / "job.yml").exists()
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.1.2).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_job_parses_successfully(job):
+    """The job.yml MUST pass schema validation."""
+    assert job is not None
+    assert job.name == "record"
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.1.3).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_job_has_four_steps(job):
+    """The job MUST define exactly four steps."""
+    assert len(job.steps) == 4
+    step_ids = [s.id for s in job.steps]
+    assert step_ids == ["observe", "document", "reflect", "generate_job"]
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.1.4).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_record_workflow_sequences_all_steps(job):
+    """The job MUST define a record workflow sequencing all four steps."""
+    workflow = next((w for w in job.workflows if w.name == "record"), None)
+    assert workflow is not None
+    assert workflow.steps == ["observe", "document", "reflect", "generate_job"]
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.2.1).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_observe_no_inputs(job):
+    """The observe step MUST NOT require any user-provided inputs."""
+    observe = next(s for s in job.steps if s.id == "observe")
+    assert observe.inputs == []
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.2.2).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_observe_empty_outputs(job):
+    """The observe step MUST have empty outputs."""
+    observe = next(s for s in job.steps if s.id == "observe")
+    assert observe.outputs == []
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.3.1).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_document_no_file_inputs_from_observe(job):
+    """The document step MUST NOT consume file inputs from the observe step."""
+    document = next(s for s in job.steps if s.id == "document")
+    file_inputs_from_observe = [
+        i for i in document.inputs if i.file is not None and i.from_step == "observe"
+    ]
+    assert file_inputs_from_observe == []
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.3.2).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_document_produces_process_document(job):
+    """The document step MUST produce a process_document.md output."""
+    document = next(s for s in job.steps if s.id == "document")
+    output_names = [o.name for o in document.outputs]
+    assert "process_document.md" in output_names
+    output = next(o for o in document.outputs if o.name == "process_document.md")
+    assert output.required is True
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.3.5).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_document_has_quality_reviews(job):
+    """The document step MUST have quality reviews."""
+    document = next(s for s in job.steps if s.id == "document")
+    assert len(document.reviews) > 0
+    criteria_keys = set()
+    for review in document.reviews:
+        criteria_keys.update(review.quality_criteria.keys())
+    assert "Complete Coverage" in criteria_keys
+    assert "Clear Structure" in criteria_keys
+    assert "User Clarification Incorporated" in criteria_keys
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.4.1).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_reflect_consumes_process_document(job):
+    """The reflect step MUST consume process_document.md from document."""
+    reflect = next(s for s in job.steps if s.id == "reflect")
+    file_inputs = [i for i in reflect.inputs if i.file == "process_document.md"]
+    assert len(file_inputs) == 1
+    assert file_inputs[0].from_step == "document"
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.4.2).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_reflect_produces_reflection(job):
+    """The reflect step MUST produce a reflection.md output."""
+    reflect = next(s for s in job.steps if s.id == "reflect")
+    output_names = [o.name for o in reflect.outputs]
+    assert "reflection.md" in output_names
+    output = next(o for o in reflect.outputs if o.name == "reflection.md")
+    assert output.required is True
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.4.4).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_reflect_has_quality_reviews(job):
+    """The reflect step MUST have quality reviews."""
+    reflect = next(s for s in job.steps if s.id == "reflect")
+    assert len(reflect.reviews) > 0
+    criteria_keys = set()
+    for review in reflect.reviews:
+        criteria_keys.update(review.quality_criteria.keys())
+    assert "Actionable Improvements" in criteria_keys
+    assert "Stumbling Blocks Identified" in criteria_keys
+    assert "Grounded in Evidence" in criteria_keys
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.5.1).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_generate_job_consumes_both_inputs(job):
+    """The generate_job step MUST consume process_document.md and reflection.md."""
+    gen = next(s for s in job.steps if s.id == "generate_job")
+    file_inputs = {i.file: i.from_step for i in gen.inputs if i.file is not None}
+    assert file_inputs == {
+        "process_document.md": "document",
+        "reflection.md": "reflect",
+    }
+
+
+# THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-011.5.2).
+# YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+def test_generate_job_produces_confirmation(job):
+    """The generate_job step MUST produce a job_created.md output."""
+    gen = next(s for s in job.steps if s.id == "generate_job")
+    output_names = [o.name for o in gen.outputs]
+    assert "job_created.md" in output_names
+    output = next(o for o in gen.outputs if o.name == "job_created.md")
+    assert output.required is True

--- a/tests/unit/jobs/test_record_standard_job.py
+++ b/tests/unit/jobs/test_record_standard_job.py
@@ -7,11 +7,7 @@ import pytest
 from deepwork.jobs.parser import parse_job_definition
 
 RECORD_JOB_DIR = (
-    Path(__file__).parent.parent.parent.parent
-    / "src"
-    / "deepwork"
-    / "standard_jobs"
-    / "record"
+    Path(__file__).parent.parent.parent.parent / "src" / "deepwork" / "standard_jobs" / "record"
 )
 
 


### PR DESCRIPTION
## Summary

- Adds a new `record` standard job that observes a user performing a process with AI assistance, documents it, reflects on improvements, and generates a reusable DeepWork job from the recording
- Four-step workflow: `observe` → `document` → `reflect` → `generate_job` (defers to existing `deepwork_jobs/new_job`)
- Includes JOBS-REQ-011 requirement spec, documentation updates, and `.deepreview` rule

## Test plan

- [ ] `deepwork serve` discovers the record job via `get_workflows`
- [ ] `start_workflow` with `job_name="record"` returns the observe step instructions
- [ ] job.yml passes schema validation
- [ ] End-to-end test: record a simple process and verify job generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)