### PR TITLE
feat: enforce DeepPlan workflow before ExitPlanMode

### DIFF
--- a/plugins/claude/hooks/deepplan_exit.sh
+++ b/plugins/claude/hooks/deepplan_exit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# DeepPlan exit guard hook
+# PreToolUse hook for ExitPlanMode - enforces DeepPlan workflow
+
+INPUT=$(cat)
+export DEEPWORK_HOOK_PLATFORM="claude"
+echo "${INPUT}" | deepwork hook deepplan_exit
+exit $?

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -31,6 +31,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/deepplan_exit.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/src/deepwork/hooks/deepplan_exit.py
+++ b/src/deepwork/hooks/deepplan_exit.py
@@ -1,0 +1,119 @@
+"""PreToolUse hook for ExitPlanMode — enforces DeepPlan workflow.
+
+Fires before ExitPlanMode. Checks if a deepplan workflow is active and
+at the present_plan step. Blocks otherwise with instructions to start
+or continue the workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from deepwork.hooks.wrapper import (
+    HookInput,
+    HookOutput,
+    NormalizedEvent,
+    Platform,
+    output_hook_error,
+    run_hook,
+)
+
+
+def deepplan_exit_hook(hook_input: HookInput) -> HookOutput:
+    """Pre-tool hook: enforce deepplan workflow before ExitPlanMode."""
+    if hook_input.event != NormalizedEvent.BEFORE_TOOL:
+        return HookOutput()
+
+    if hook_input.tool_name != "exit_plan_mode":
+        return HookOutput()
+
+    session_id = hook_input.session_id
+    if not session_id:
+        return HookOutput()
+
+    cwd = hook_input.cwd or os.getcwd()
+    project_root = Path(cwd)
+
+    state = _read_deepplan_state(project_root, session_id)
+
+    if state == "at_present_plan":
+        return HookOutput()
+    elif state == "completed":
+        return HookOutput()
+    elif state == "active_not_at_present_plan":
+        return HookOutput(
+            decision="block",
+            reason=(
+                "The DeepPlan workflow is still in progress. "
+                "Continue working through the workflow steps — "
+                "ExitPlanMode should only be called during the `present_plan` step. "
+                "Call `finished_step` to advance to the next step."
+            ),
+        )
+    else:
+        # No deepplan workflow found
+        return HookOutput(
+            decision="block",
+            reason=(
+                "Before exiting plan mode, start the DeepPlan workflow by calling "
+                "`start_workflow` with job_name='deepplan' and "
+                "workflow_name='create_deep_plan'. The workflow will guide you "
+                "through structured planning and tell you when to call ExitPlanMode."
+            ),
+        )
+
+
+def _read_deepplan_state(project_root: Path, session_id: str) -> str:
+    """Check deepplan workflow state from session state files.
+
+    Returns one of:
+        "at_present_plan" — active deepplan workflow at present_plan step
+        "active_not_at_present_plan" — active deepplan but not at present_plan
+        "completed" — deepplan workflow was completed
+        "none" — no deepplan workflow found
+    """
+    session_dir = (
+        project_root / ".deepwork" / "tmp" / "sessions" / "claude" / f"session-{session_id}"
+    )
+
+    if not session_dir.exists():
+        return "none"
+
+    for state_file in session_dir.iterdir():
+        if state_file.suffix != ".json":
+            continue
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        # Check active workflow stack
+        for entry in data.get("workflow_stack", []):
+            if entry.get("job_name") == "deepplan":
+                if entry.get("current_step_id") == "present_plan":
+                    return "at_present_plan"
+                return "active_not_at_present_plan"
+
+        # Check completed workflows
+        for entry in data.get("completed_workflows", []):
+            if entry.get("job_name") == "deepplan" and entry.get("status") == "completed":
+                return "completed"
+
+    return "none"
+
+
+def main() -> int:
+    """Entry point for the hook CLI."""
+    platform = Platform(os.environ.get("DEEPWORK_HOOK_PLATFORM", "claude"))
+    return run_hook(deepplan_exit_hook, platform)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        output_hook_error(e, context="deepplan_exit hook")
+        sys.exit(0)

--- a/src/deepwork/hooks/wrapper.py
+++ b/src/deepwork/hooks/wrapper.py
@@ -122,6 +122,7 @@ TOOL_TO_NORMALIZED: dict[Platform, dict[str, str]] = {
         "WebFetch": "web_fetch",
         "WebSearch": "web_search",
         "Task": "task",
+        "ExitPlanMode": "exit_plan_mode",
     },
     Platform.GEMINI: {
         # Gemini already uses snake_case
@@ -148,6 +149,7 @@ NORMALIZED_TO_TOOL: dict[Platform, dict[str, str]] = {
         "web_fetch": "WebFetch",
         "web_search": "WebSearch",
         "task": "Task",
+        "exit_plan_mode": "ExitPlanMode",
     },
     Platform.GEMINI: {
         # Gemini already uses snake_case

--- a/tests/unit/test_deepplan_exit_hook.py
+++ b/tests/unit/test_deepplan_exit_hook.py
@@ -1,0 +1,211 @@
+"""Tests for the deepplan_exit PreToolUse hook."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepwork.hooks.deepplan_exit import _read_deepplan_state, deepplan_exit_hook
+from deepwork.hooks.wrapper import HookInput, NormalizedEvent, Platform
+
+
+def _make_hook_input(
+    *,
+    event: NormalizedEvent = NormalizedEvent.BEFORE_TOOL,
+    tool_name: str = "exit_plan_mode",
+    session_id: str = "test-session",
+    cwd: str = "",
+) -> HookInput:
+    return HookInput(
+        platform=Platform.CLAUDE,
+        event=event,
+        session_id=session_id,
+        tool_name=tool_name,
+        cwd=cwd,
+    )
+
+
+def _write_state(session_dir: Path, filename: str, data: dict) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / filename).write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestGuardConditions:
+    """Hook should return empty HookOutput (allow) for non-matching events."""
+
+    def test_wrong_event_type(self) -> None:
+        hook_input = _make_hook_input(event=NormalizedEvent.AFTER_TOOL)
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+    def test_wrong_tool_name(self) -> None:
+        hook_input = _make_hook_input(tool_name="write_file")
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+    def test_missing_session_id(self) -> None:
+        hook_input = _make_hook_input(session_id="")
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+
+class TestBlockCases:
+    """Hook should block when deepplan workflow is not at present_plan."""
+
+    def test_no_session_directory(self, tmp_path: Path) -> None:
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == "block"
+        assert "start_workflow" in result.reason
+
+    def test_active_deepplan_not_at_present_plan(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        _write_state(
+            session_dir,
+            "state.json",
+            {
+                "workflow_stack": [
+                    {
+                        "job_name": "deepplan",
+                        "workflow_name": "create_deep_plan",
+                        "current_step_id": "initial_understanding",
+                        "status": "active",
+                    }
+                ]
+            },
+        )
+
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == "block"
+        assert "finished_step" in result.reason
+
+    def test_empty_workflow_stack(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        _write_state(session_dir, "state.json", {"workflow_stack": []})
+
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == "block"
+        assert "start_workflow" in result.reason
+
+
+class TestAllowCases:
+    """Hook should allow when deepplan is at present_plan or completed."""
+
+    def test_active_deepplan_at_present_plan(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        _write_state(
+            session_dir,
+            "state.json",
+            {
+                "workflow_stack": [
+                    {
+                        "job_name": "deepplan",
+                        "workflow_name": "create_deep_plan",
+                        "current_step_id": "present_plan",
+                        "status": "active",
+                    }
+                ]
+            },
+        )
+
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+    def test_completed_deepplan(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        _write_state(
+            session_dir,
+            "state.json",
+            {
+                "workflow_stack": [],
+                "completed_workflows": [
+                    {
+                        "job_name": "deepplan",
+                        "workflow_name": "create_deep_plan",
+                        "current_step_id": "present_plan",
+                        "status": "completed",
+                    }
+                ],
+            },
+        )
+
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+
+class TestAgentStateFiles:
+    """Hook should detect deepplan in agent-specific state files."""
+
+    def test_deepplan_in_agent_state_file(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        # Main state has no deepplan
+        _write_state(session_dir, "state.json", {"workflow_stack": []})
+        # Agent state has deepplan at present_plan
+        _write_state(
+            session_dir,
+            "agent_abc123.json",
+            {
+                "workflow_stack": [
+                    {
+                        "job_name": "deepplan",
+                        "workflow_name": "create_deep_plan",
+                        "current_step_id": "present_plan",
+                        "status": "active",
+                    }
+                ]
+            },
+        )
+
+        hook_input = _make_hook_input(cwd=str(tmp_path))
+        result = deepplan_exit_hook(hook_input)
+        assert result.decision == ""
+
+
+class TestReadDeepplanState:
+    """Direct tests of the _read_deepplan_state helper."""
+
+    def test_nonexistent_session_dir(self, tmp_path: Path) -> None:
+        assert _read_deepplan_state(tmp_path, "nonexistent") == "none"
+
+    def test_corrupt_json(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / "state.json").write_text("not json", encoding="utf-8")
+        assert _read_deepplan_state(tmp_path, "test-session") == "none"
+
+    def test_non_deepplan_workflow(self, tmp_path: Path) -> None:
+        session_dir = (
+            tmp_path / ".deepwork" / "tmp" / "sessions" / "claude" / "session-test-session"
+        )
+        _write_state(
+            session_dir,
+            "state.json",
+            {
+                "workflow_stack": [
+                    {
+                        "job_name": "other_job",
+                        "current_step_id": "some_step",
+                        "status": "active",
+                    }
+                ]
+            },
+        )
+        assert _read_deepplan_state(tmp_path, "test-session") == "none"


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` hook that intercepts `ExitPlanMode` and blocks it unless the DeepPlan workflow is at the `present_plan` step (or already completed)
- Implements the hook as a Python module (`deepwork hook deepplan_exit`) that reads workflow state files from disk
- Registers the hook in the Claude plugin's `hooks.json` with an `ExitPlanMode` matcher

## Files

- `src/deepwork/hooks/deepplan_exit.py` — Hook logic with 4-state decision tree
- `plugins/claude/hooks/deepplan_exit.sh` — Shell wrapper
- `plugins/claude/hooks/hooks.json` — PreToolUse registration
- `src/deepwork/hooks/wrapper.py` — Added ExitPlanMode to tool name mappings
- `tests/unit/test_deepplan_exit_hook.py` — 12 tests covering all paths

## Test plan

- [x] `uv run pytest tests/unit/test_deepplan_exit_hook.py -v` — 12 tests pass
- [x] `uv run pytest tests/unit/test_hook_wrapper.py -v` — 44 existing wrapper tests still pass
- [x] hooks.json validates as valid JSON
- [x] Shell wrapper is executable
- [ ] Manual: enter plan mode, try ExitPlanMode without deepplan → should block
- [ ] Manual: start deepplan workflow, reach present_plan, ExitPlanMode → should allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)