### PR TITLE
feat: open success page after deepwork setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - README install commands consolidated into a single `&&`-joined command ending with `/deepwork:new_user`
+- `deepwork setup` now opens `https://www.deepwork.md/success` in the default browser after completing configuration
 
 ### Fixed
 

--- a/specs/deepwork/DW-REQ-005-cli-commands.md
+++ b/specs/deepwork/DW-REQ-005-cli-commands.md
@@ -87,3 +87,4 @@ The DeepWork CLI provides five active commands: `serve` (starts the MCP server),
 5. The command MUST preserve existing settings (other plugins, permissions, etc.) when adding DeepWork entries.
 6. The command MUST create `~/.claude` and `settings.json` if they do not exist.
 7. When no supported platform is detected, the command MUST print a message indicating no platforms were found.
+8. After all platform configuration is complete, the command MUST open `https://www.deepwork.md/success` in the user's default browser.

--- a/src/deepwork/cli/setup.py
+++ b/src/deepwork/cli/setup.py
@@ -1,5 +1,6 @@
 """CLI command: deepwork setup."""
 
+import webbrowser
 from pathlib import Path
 
 import click
@@ -25,3 +26,5 @@ def setup() -> None:
             click.echo("Claude Code — already configured, no changes needed.")
     else:
         click.echo("No supported AI agent platforms detected (~/.claude not found).")
+
+    webbrowser.open("https://www.deepwork.md/success")

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import click.testing
 import pytest
@@ -132,3 +133,11 @@ class TestSetupCLI:
         result = runner.invoke(cli, ["setup"])
         assert result.exit_code == 0
         assert "No supported" in result.output
+
+    # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.6.8).
+    # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
+    def test_opens_success_page(self, claude_home: Path) -> None:
+        with patch("deepwork.cli.setup.webbrowser.open") as mock_open:
+            runner = click.testing.CliRunner()
+            runner.invoke(cli, ["setup"])
+            mock_open.assert_called_once_with("https://www.deepwork.md/success")

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -110,6 +110,11 @@ class TestClaudeSetupNoClaudeDir:
 class TestSetupCLI:
     """Tests for the setup CLI command itself."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_browser(self) -> None:  # noqa: PT004
+        with patch("deepwork.cli.setup.webbrowser.open"):
+            yield
+
     # THIS TEST VALIDATES A HARD REQUIREMENT (DW-REQ-005.6.1).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_setup_is_click_command(self) -> None:


### PR DESCRIPTION
## Summary
- Opens `https://www.deepwork.md/success` in the user's default browser as the final step of `deepwork setup`
- Uses Python's stdlib `webbrowser` module for cross-platform compatibility (no new dependencies)

## Test plan
- [ ] Run `deepwork setup` and verify the success page opens in the default browser
- [ ] Verify on macOS and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)