### PR TITLE
fix: remove DeepPlan injection, rename Task tool to Agent tool

### DIFF
--- a/.deepwork/learning-agents/consistency-reviewer/topics/mcp-workflow-patterns.md
+++ b/.deepwork/learning-agents/consistency-reviewer/topics/mcp-workflow-patterns.md
@@ -68,7 +68,7 @@ steps:
 When the server encounters a concurrent entry, it:
 1. Uses the first step ID as the "current" step
 2. Appends a `**CONCURRENT STEPS**` message to the instructions
-3. Expects the agent to use the Task tool to execute them in parallel
+3. Expects the agent to use the Agent tool to execute them in parallel
 
 **Consistency check**: The `current_entry_index` tracks position in the `step_entries` list (which may contain concurrent groups), not the flat step list.
 

--- a/.github/workflows/claude-code-test.yml
+++ b/.github/workflows/claude-code-test.yml
@@ -219,9 +219,11 @@ jobs:
           # The plugin (--plugin-dir) provides skills, hooks, and MCP server config.
           # Override the plugin's MCP config to use the bare `deepwork` command
           # (the plugin uses `uvx` which may not resolve the local venv install).
+          # Server is named "deepwork-dev" to match the reviewer agent's tool
+          # patterns (mcp__deepwork-dev__*) — see CLAUDE.md MCP tool naming.
           python3 -c "
           import json
-          mcp = {'mcpServers': {'deepwork': {
+          mcp = {'mcpServers': {'deepwork-dev': {
               'command': 'deepwork',
               'args': ['serve', '--path', '.', '--platform', 'claude']
           }}}
@@ -236,10 +238,10 @@ jobs:
               'permissions': {
                   'allow': [
                       'Bash(*)', 'Read(./**)', 'Edit(./**)', 'Write(./**)', 'Skill(*)',
-                      'mcp__deepwork__get_workflows', 'mcp__deepwork__start_workflow',
-                      'mcp__deepwork__finished_step', 'mcp__deepwork__abort_workflow',
-                      'mcp__deepwork__go_to_step',
-                      'mcp__deepwork__mark_review_as_passed'
+                      'mcp__deepwork-dev__get_workflows', 'mcp__deepwork-dev__start_workflow',
+                      'mcp__deepwork-dev__finished_step', 'mcp__deepwork-dev__abort_workflow',
+                      'mcp__deepwork-dev__go_to_step',
+                      'mcp__deepwork-dev__mark_review_as_passed'
                   ]
               }
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ deepwork/
 │   ├── claude/           # Claude Code plugin
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── README_REVIEWS.md
+│   │   ├── agents/         # Subagent definitions (e.g., reviewer.md)
 │   │   ├── example_reviews/
 │   │   ├── skills/
 │   │   │   ├── configure_reviews/SKILL.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Post-commit review reminder hook now short-circuits when all applicable (non-catch-all) review rules for the committed files are already marked as passed, emitting "No re-review needed" instead of nagging
+- Renamed all "Task tool" references to "Agent tool" across codebase to match Claude Code's current tool naming
+- Review formatter now emits `description`, `subagent_type`, and `prompt` fields (dropped `name` field) to match Agent tool signature
+- Hook wrapper tool mappings updated: `Task`/`task` → `Agent`/`agent`
 
 ### Fixed
 
 - Review instruction files now include a `## Project Root` directive stating the absolute project root so reviewer subagents read files from the correct working tree — fixes spurious findings in git-worktree setups where the subagent's cwd differed from the worktree the commits actually lived in (REVIEW-REQ-005.1.9)
 
 ### Removed
+
+- Removed automatic DeepPlan workflow injection from startup_context.sh hook (no longer forces plan mode into DeepPlan)
+- Deprecated JOBS-REQ-014.5.1 (startup hook DeepPlan trigger) and REVIEW-REQ-006.3.3a (name field in review output)
 ## [0.13.3] - 2026-04-10
 
 ### Added

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -872,7 +872,7 @@ Lists all available workflows from `.deepwork/jobs/`.
 
 **Parameters**: None
 
-**Returns**: List of jobs with their workflows, steps, and summaries. Each `WorkflowInfo` includes a `how_to_invoke` field with invocation instructions: when the workflow's `agent` field is set in job.yml, it directs callers to delegate via the Task tool; otherwise, it directs callers to use the `start_workflow` MCP tool directly.
+**Returns**: List of jobs with their workflows, steps, and summaries. Each `WorkflowInfo` includes a `how_to_invoke` field with invocation instructions: when the workflow's `agent` field is set in job.yml, it directs callers to delegate via the Agent tool; otherwise, it directs callers to use the `start_workflow` MCP tool directly.
 
 #### 2. `start_workflow`
 Begins a new workflow session.

--- a/doc/job_yml_guidance.md
+++ b/doc/job_yml_guidance.md
@@ -82,11 +82,11 @@ Changes how the workflow appears in `get_workflows`. Without `agent`, the respon
 
 > Call `start_workflow` with job_name="X" and workflow_name="Y", then follow the step instructions it returns.
 
-With `agent` set (e.g., `"general-purpose"`), the response tells the caller to spawn a **Task sub-agent** of that type:
+With `agent` set (e.g., `"general-purpose"`), the response tells the caller to spawn a sub-agent of that type:
 
-> Invoke as a Task using subagent_type="general-purpose" with a prompt giving full context and instructions to call `start_workflow`...
+> Invoke as an Agent using subagent_type="general-purpose" with a prompt giving full context and instructions to call `start_workflow`...
 
-If the agent does not have the Task tool available, the instructions fall back to direct invocation.
+If the agent does not have the Agent tool available, the instructions fall back to direct invocation.
 
 Use `agent` for workflows that should execute autonomously without blocking the main conversation.
 

--- a/doc/learning_agents_architecture.md
+++ b/doc/learning_agents_architecture.md
@@ -13,8 +13,8 @@ A sub-agent with a persistent knowledge base that improves over time. Defined in
 
 ### Learning Cycle
 The feedback loop that makes agents improve:
-1. **Use** — Agent is invoked via Task tool during normal work
-2. **Track** — Post-Task hook records the session for later review
+1. **Use** — Agent is invoked via Agent tool during normal work
+2. **Track** — Post-Agent hook records the session for later review
 3. **Identify** — Transcript is reviewed for issues/mistakes
 4. **Investigate** — Root causes are determined from transcript evidence
 5. **Incorporate** — Learnings are folded back into the agent's knowledge base
@@ -324,4 +324,4 @@ Issues are tied to specific transcripts for evidence. Storing them alongside ses
 The `learn` skill spawns identification tasks using the Sonnet model. Transcript review is high-volume, pattern-matching work that doesn't require the most capable model. This keeps learning cycles fast and cost-effective.
 
 ### Why Hidden Skills
-Skills like `identify`, `report-issue`, `investigate-issues`, and `incorporate-learnings` are implementation details of the learning cycle. They're invoked by the `learn` skill via Task delegation, not directly by users. Hiding them keeps the user-facing skill surface clean.
+Skills like `identify`, `report-issue`, `investigate-issues`, and `incorporate-learnings` are implementation details of the learning cycle. They're invoked by the `learn` skill via Agent delegation, not directly by users. Hiding them keeps the user-facing skill surface clean.

--- a/doc/learning_agents_architecture.md
+++ b/doc/learning_agents_architecture.md
@@ -250,12 +250,12 @@ After the script runs, the skill prompts the user to describe what the agent is 
 Fills in key files in the LearningAgent directory — initial topics and/or learnings if the user provides seed knowledge about the domain.
 
 #### learn
-Runs the full learning cycle on all sessions needing it. The skill takes no arguments — any text after `learn` is ignored. Sessions are processed sequentially (not in parallel) to avoid conflicts when the same agent appears in multiple sessions. Workflow:
-1. Uses `!`find ...`` to inject a list of all paths containing a `needs_learning_as_of_timestamp` file into the prompt
-2. For each such folder, spawns a Task with the `LearningAgentExpert` agent using **Sonnet model** to run the `identify` skill
-3. After identification completes, spawns a Task with the `LearningAgentExpert` to run `investigate-issues` then `incorporate-learnings` in sequence
+Runs the full learning cycle on all sessions needing it. The skill takes no arguments. Workflow:
+1. Uses a script to inject a list of all paths containing a `needs_learning_as_of_timestamp` file into the prompt
+2. Spawns an Agent per session with the `LearningAgentExpert` agent using **Sonnet model** to run the `identify` skill — **all run in parallel**
+3. After identification completes, skips sessions where zero issues were found; for remaining sessions, spawns an Agent per session to run `investigate-issues` then `incorporate-learnings` in sequence — **sessions for different agents run in parallel; sessions for the same agent run serially**
 
-If no pending sessions are found (or the `.deepwork/tmp/agent_sessions/` directory is missing), the skill informs the user and stops. If a sub-skill Task fails for a session, the skill logs the failure, skips that session, continues processing remaining sessions, and does NOT mark `needs_learning_as_of_timestamp` as resolved. On completion, the skill outputs a summary containing total sessions processed, total issues identified, list of agents updated, key learnings per agent, and any skipped sessions with reasons. The `learn` skill itself MUST NOT modify agent files directly — all knowledge base updates are delegated to the sub-skills.
+If no pending sessions are found (or the `.deepwork/tmp/agent_sessions/` directory is missing), the skill informs the user and stops. If a sub-skill Agent fails for a session, the skill logs the failure, skips that session, continues processing remaining sessions, and does NOT mark `needs_learning_as_of_timestamp` as resolved. On completion, the skill outputs a summary containing total sessions processed, total issues identified, list of agents updated, key learnings per agent, and any skipped sessions with reasons. The `learn` skill itself MUST NOT modify agent files directly — all knowledge base updates are delegated to the sub-skills.
 
 #### setup
 Configures project permissions for the LearningAgents plugin. Adds required Bash and file access rules to `.claude/settings.json` so hooks and scripts can run without manual approval.

--- a/doc/mcp_interface.md
+++ b/doc/mcp_interface.md
@@ -183,7 +183,7 @@ Navigate back to a prior step in the current workflow. Clears all progress from 
 
 ### 6. `get_review_instructions`
 
-Run a review of changed files based on `.deepreview` configuration files and DeepSchema-generated synthetic review rules. Returns a list of review tasks to invoke in parallel. Each task has `name`, `description`, `subagent_type`, and `prompt` fields for the Task tool.
+Run a review of changed files based on `.deepreview` configuration files and DeepSchema-generated synthetic review rules. Returns a list of review tasks to invoke in parallel. Each task has `description`, `subagent_type`, and `prompt` fields for the Agent tool.
 
 This tool operates outside the workflow lifecycle — it can be called independently at any time.
 
@@ -402,7 +402,7 @@ The quality gate builds dynamic `ReviewRule` objects from step output review blo
 - **Job context**: The workflow's `common_job_info` (if any)
 - **Step inputs**: Input values from prior steps, with file_path inputs shown as `@path` references
 
-These rules are then processed through the standard DeepWork Reviews pipeline (matched against output files, instruction files written, formatted for the agent platform). The review output directs the agent to launch parallel Task agents for each review.
+These rules are then processed through the standard DeepWork Reviews pipeline (matched against output files, instruction files written, formatted for the agent platform). The review output directs the agent to launch parallel review agents for each review.
 
 ### Review Types
 
@@ -496,7 +496,7 @@ Add to your `.mcp.json`:
 | 2.1.0 | Added `important_note` field to `StartWorkflowResponse` — instructs agents to clarify ambiguous user requests via `AskUserQuestion` when available. |
 | 2.0.0 | **Breaking**: `session_id` is now a required `string` parameter on all mutation tools (`start_workflow`, `finished_step`, `abort_workflow`, `go_to_step`). Added `agent_id` optional parameter for sub-agent scoping — sub-agents get their own isolated workflow stacks. State persistence path changed to `.deepwork/tmp/sessions/<platform>/session-<id>/state.json` (with sub-agent state in `agent_<agent_id>.json`). |
 | 1.9.0 | Added `go_to_step` tool for navigating back to prior steps. Clears all step progress from the target step onward, forcing re-execution of subsequent steps. Supports `session_id` for concurrent workflow safety. |
-| 1.8.0 | Added `how_to_invoke` field to `WorkflowInfo` in `get_workflows` response. Always populated with invocation instructions: when a workflow's `agent` field is set, directs callers to delegate via the Task tool; otherwise, directs callers to use the `start_workflow` MCP tool directly. Also added optional `agent` field to workflow definitions in job.yml. |
+| 1.8.0 | Added `how_to_invoke` field to `WorkflowInfo` in `get_workflows` response. Always populated with invocation instructions: when a workflow's `agent` field is set, directs callers to delegate via the Agent tool; otherwise, directs callers to use the `start_workflow` MCP tool directly. Also added optional `agent` field to workflow definitions in job.yml. |
 | 1.7.0 | Added `mark_review_as_passed` tool for review pass caching. Instruction files now include an "After Review" section with the review ID. Reviews with a `.passed` marker are automatically skipped by `get_review_instructions`. |
 | 1.6.0 | Added `get_configured_reviews` tool for listing configured review rules without running the full pipeline. Supports optional file-based filtering. |
 | 1.5.0 | Added `get_review_instructions` tool (originally named `review`) for running `.deepreview`-based code reviews via MCP. Added `--platform` CLI option to `serve` command. |

--- a/learning_agents/agents/learning-agent-expert.md
+++ b/learning_agents/agents/learning-agent-expert.md
@@ -21,7 +21,7 @@ You are the meta-expert that operates on LearningAgent files. You understand the
 
 !`cat ${CLAUDE_PLUGIN_ROOT}/doc/learning_log_folder_structure.md`
 
-### Post-Task Reminder
+### Post-Agent Reminder
 
 !`cat ${CLAUDE_PLUGIN_ROOT}/doc/learning_agent_post_task_reminder.md`
 

--- a/learning_agents/doc/learning_log_folder_structure.md
+++ b/learning_agents/doc/learning_log_folder_structure.md
@@ -19,13 +19,13 @@ Session-level agent interaction logs are stored in `.deepwork/tmp/agent_sessions
 
 ### conversation_transcript.jsonl
 
-A symlink to the agent's Claude Code transcript, created automatically by the post-Task hook. Points to the subagent transcript at `~/.claude/projects/<project-hash>/<session_id>/subagents/agent-<agent_id>.jsonl`. This allows learning cycle skills to read the transcript directly from the session log folder without needing to search for it via Glob patterns.
+A symlink to the agent's Claude Code transcript, created automatically by the post-Agent hook. Points to the subagent transcript at `~/.claude/projects/<project-hash>/<session_id>/subagents/agent-<agent_id>.jsonl`. This allows learning cycle skills to read the transcript directly from the session log folder without needing to search for it via Glob patterns.
 
-The symlink is only created if the transcript file exists at hook execution time (which it should, since the PostToolUse hook fires after the Task completes).
+The symlink is only created if the transcript file exists at hook execution time (which it should, since the PostToolUse hook fires after the Agent completes).
 
 ### needs_learning_as_of_timestamp
 
-Created automatically by the post-Task hook whenever a LearningAgent is used. The file body contains a single ISO 8601 timestamp indicating when the agent was last invoked. This file serves as a flag: its presence means the session transcript has not yet been processed for learnings.
+Created automatically by the post-Agent hook whenever a LearningAgent is used. The file body contains a single ISO 8601 timestamp indicating when the agent was last invoked. This file serves as a flag: its presence means the session transcript has not yet been processed for learnings.
 
 Deleted by `incorporate_learnings` after all issues in the folder have been processed.
 
@@ -35,7 +35,7 @@ Updated by `incorporate_learnings` after processing issues in this conversation.
 
 ### agent_used
 
-Created automatically by the post-Task hook. Contains the name of the LearningAgent that was used in this session (matching the folder name under `.deepwork/learning-agents/`). This links the session's agent_id back to the LearningAgent definition so learning skills can look up the agent's instructions and knowledge.
+Created automatically by the post-Agent hook. Contains the name of the LearningAgent that was used in this session (matching the folder name under `.deepwork/learning-agents/`). This links the session's agent_id back to the LearningAgent definition so learning skills can look up the agent's instructions and knowledge.
 
 ### *.issue.yml
 
@@ -43,11 +43,11 @@ Issue files created during the `identify` and `report_issue` skills. See `issue_
 
 ### conversation_transcript.jsonl
 
-Symlink to the agent's Claude Code transcript, created automatically by the post-Task hook. **THIS IS THE FILE TO READ TO SEE THE CONVERSATION ALL THE OTHER FILES REFER TO.**
+Symlink to the agent's Claude Code transcript, created automatically by the post-Agent hook. **THIS IS THE FILE TO READ TO SEE THE CONVERSATION ALL THE OTHER FILES REFER TO.**
 
 ## Lifecycle
 
-1. **Agent used**: Post-Task hook creates `needs_learning_as_of_timestamp`, `agent_used`, and `conversation_transcript.jsonl` symlink
+1. **Agent used**: Post-Agent hook creates `needs_learning_as_of_timestamp`, `agent_used`, and `conversation_transcript.jsonl` symlink
 2. **Session ends**: Stop hook detects `needs_learning_as_of_timestamp` files and suggests running a learning cycle
 3. **Learning cycle** (`/learning-agents learn`):
    a. `identify` reads transcripts and creates `*.issue.yml` files with status `identified`

--- a/learning_agents/hooks/post_task.sh
+++ b/learning_agents/hooks/post_task.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# post_task.sh - PostToolUse hook for Task tool
+# post_task.sh - PostToolUse hook for Agent tool
 #
-# Detects when a LearningAgent is used via Task and creates session tracking
+# Detects when a LearningAgent is used via Agent and creates session tracking
 # files so the learning cycle can process the transcript later.
 #
 # Input (stdin): JSON with tool_input, tool_response, session_id

--- a/learning_agents/skills/create-agent/SKILL.md
+++ b/learning_agents/skills/create-agent/SKILL.md
@@ -127,7 +127,7 @@ is **invisible** to Claude until you restart.
 
 1. Exit this Claude Code session (type `/exit` or Ctrl+C)
 2. Restart with: `claude -c` (this continues your conversation)
-3. The new agent will then be available via the Task tool
+3. The new agent will then be available via the Agent tool
 
 If you skip this step, Claude will not find the agent when you try to use it.
 
@@ -138,10 +138,10 @@ After the restart warning, output:
 
 ```
 **Usage (after restart):**
-  Use the Task tool with `name: "<agent-name>"` to invoke this agent.
+  Use the Agent tool with `subagent_type: "<agent-name>"` to invoke this agent.
 
 **Learning cycle:**
-  The post-Task hook will automatically track sessions. Run `/learning-agents learn`
+  The post-Agent hook will automatically track sessions. Run `/learning-agents learn`
   after sessions to identify and incorporate learnings.
 ```
 

--- a/learning_agents/skills/learn/.deepschema.SKILL.md.yml
+++ b/learning_agents/skills/learn/.deepschema.SKILL.md.yml
@@ -16,8 +16,8 @@ requirements:
   # LA-REQ-006.6
   task-tool-orchestration: >
     The SKILL.md MUST instruct the agent to run the identify phase as a
-    separate Task tool invocation, and to combine the investigate-issues
-    and incorporate-learnings phases into a single Task tool invocation
+    separate Agent tool invocation, and to combine the investigate-issues
+    and incorporate-learnings phases into a single Agent tool invocation
     (executed in that order). It MUST reference the
     `learning-agents:identify`, `learning-agents:investigate-issues`,
     and `learning-agents:incorporate-learnings` skills by name.
@@ -25,7 +25,7 @@ requirements:
   # LA-REQ-006.7
   sonnet-model-for-subtasks: >
     The SKILL.md MUST instruct the agent to use the Sonnet model for
-    Task spawns of learning cycle sub-skills, to balance cost and
+    Agent spawns of learning cycle sub-skills, to balance cost and
     quality.
 
   # LA-REQ-006.8
@@ -36,7 +36,7 @@ requirements:
 
   # LA-REQ-006.9
   failure-handling: >
-    The SKILL.md MUST instruct the agent that, if a sub-skill Task fails
+    The SKILL.md MUST instruct the agent that, if a sub-skill Agent fails
     for a session, it must: log the failure, skip that session, continue
     processing remaining sessions, and NOT mark
     needs_learning_as_of_timestamp as resolved for the failed session.

--- a/learning_agents/skills/learn/SKILL.md
+++ b/learning_agents/skills/learn/SKILL.md
@@ -25,11 +25,11 @@ For each session log folder, run the learning cycle in sequence.
 
 #### 1a: Identify Issues
 
-Spawn a Task to run the identify skill:
+Spawn an Agent to run the identify skill:
 
 ```
-Task tool call:
-  name: "identify-issues"
+Agent tool call:
+  description: "Identify issues"
   subagent_type: learning-agents:learning-agent-expert
   model: sonnet
   prompt: "Run: Skill learning-agents:identify <session_log_folder>"
@@ -41,11 +41,11 @@ Task tool call:
 
 After identification completes, **skip** any session where the identify step reported zero issues. Only proceed with sessions that had issues identified.
 
-For remaining sessions, start a new Task to run investigation and incorporation in sequence for each session_log_folder:
+For remaining sessions, start a new Agent to run investigation and incorporation in sequence for each session_log_folder:
 
 ```
-Task tool call:
-  name: "investigate-and-incorporate"
+Agent tool call:
+  description: "Investigate and incorporate"
   subagent_type: learning-agents:learning-agent-expert
   model: sonnet
   prompt: "Run these two skills in sequence:
@@ -53,11 +53,11 @@ Task tool call:
            2. Skill learning-agents:incorporate-learnings <session_log_folder>"
 ```
 
-**Run session log folders from the same agent serially, but different agents in parallel.** I.e. if Agent A has 7 sessions and Agent B has 3 sessions, you should have 3 "batches" of Tasks where you do one session for Agent A and one for Agent B, then you would have 4 more Tasks run serially for the remaining Agent A sessions.
+**Run session log folders from the same agent serially, but different agents in parallel.** I.e. if Agent A has 7 sessions and Agent B has 3 sessions, you should have 3 "batches" of Agents where you do one session for Agent A and one for Agent B, then you would have 4 more Agents run serially for the remaining Agent A sessions.
 
 #### Handling failures
 
-If a sub-skill Task fails for a session, log the failure, skip that session, and continue processing remaining sessions. Do not mark `needs_learning_as_of_timestamp` as resolved for failed sessions.
+If a sub-skill Agent fails for a session, log the failure, skip that session, and continue processing remaining sessions. Do not mark `needs_learning_as_of_timestamp` as resolved for failed sessions.
 
 ### Step 2: Summary
 
@@ -77,5 +77,5 @@ Output in this format:
 ## Guardrails
 
 - Do NOT modify agent files directly — always delegate to the learning cycle skills in Tasks
-- Use Sonnet model for Task spawns to balance cost and quality
-- Use the `learning-agents:learning-agent-expert` agent for Task spawns
+- Use Sonnet model for Agent spawns to balance cost and quality
+- Use the `learning-agents:learning-agent-expert` agent for Agent spawns

--- a/plugins/claude/hooks/startup_context.sh
+++ b/plugins/claude/hooks/startup_context.sh
@@ -31,10 +31,6 @@ if [ -n "$AGENT_ID" ]; then
   CTX="${CTX}"$'\n'"CLAUDE_CODE_AGENT_ID=$AGENT_ID"
 fi
 
-# Inject DeepPlan trigger for planning mode
-DEEPPLAN_MSG="When you enter plan mode and begin working on a plan, start the DeepWork workflow create_deep_plan (job: deepplan) via start_workflow before doing anything else. The workflow will guide you through structured planning. Its instructions supersede the default planning phases."
-CTX="${CTX}"$'\n'"${DEEPPLAN_MSG}"
-
 # ==== Output hook response ====
 jq -n --arg ctx "$CTX" --arg event "$EVENT_NAME" \
   '{ hookSpecificOutput: { hookEventName: $event, additionalContext: $ctx } }'

--- a/plugins/claude/skills/review/SKILL.md
+++ b/plugins/claude/skills/review/SKILL.md
@@ -22,7 +22,7 @@ Only proceed past this section if the user wants to **run** reviews.
    - **No arguments** to review the current branch's changes (auto-detects via git diff against the main branch).
    - **With `files`** to review only specific files: `mcp__deepwork__get_review_instructions(files=["src/app.py", "src/lib.py"])`. When provided, only reviews whose include/exclude patterns match the given files will be returned. Use this when the user asks to review a particular file or set of files rather than the whole branch.
    - **If the result says no rules are configured**: Ask the user if they'd like to auto-discover and set up rules. If yes, invoke the `/deepwork` skill with the `deepwork_reviews` job's `discover_rules` workflow. Stop here — do not proceed with running reviews if there are no rules.
-2. The output will list review tasks to invoke in parallel. Each task has `name`, `description`, `subagent_type`, and `prompt` fields — these map directly to the Task tool parameters. Launch all of them as parallel Task agents.
+2. The output will list review tasks to invoke in parallel. Each task has `description`, `subagent_type`, and `prompt` fields — these map directly to the Agent tool parameters. Launch all of them as parallel agents.
 3. **While review agents run**, check for a changelog and open PR (see below).
 4. Collect the results from all review agents.
 

--- a/specs/deepwork/jobs/JOBS-REQ-001-mcp-workflow-tools.md
+++ b/specs/deepwork/jobs/JOBS-REQ-001-mcp-workflow-tools.md
@@ -26,7 +26,7 @@ The DeepWork MCP server exposes workflow tools to AI agents via the Model Contex
 3. The tool MUST return a dictionary with a `jobs` key containing a list of job info objects.
 4. Each job info object MUST contain `name`, `summary`, and `workflows` fields.
 5. Each workflow info object MUST contain `name`, `summary`, and `how_to_invoke` fields.
-6. When a workflow's `agent` field is set, `how_to_invoke` MUST contain instructions for delegating to a sub-agent of the specified type via the Task tool.
+6. When a workflow's `agent` field is set, `how_to_invoke` MUST contain instructions for delegating to a sub-agent of the specified type via the Agent tool.
 7. When a workflow's `agent` field is not set, `how_to_invoke` MUST contain instructions to call `start_workflow` directly.
 8. The tool MUST also return an `errors` key containing a list of job load error objects for jobs that failed to parse.
 9. Each job load error object MUST contain `job_name`, `job_dir`, and `error` fields.

--- a/specs/deepwork/jobs/JOBS-REQ-004-quality-review-system.md
+++ b/specs/deepwork/jobs/JOBS-REQ-004-quality-review-system.md
@@ -53,7 +53,7 @@ The quality review system evaluates step outputs against defined quality criteri
 ### JOBS-REQ-004.6: Review Guidance Output
 
 1. The review guidance MUST include the formatted review output from `format_for_claude()`.
-2. The guidance MUST instruct the agent to launch review tasks as parallel Task agents.
+2. The guidance MUST instruct the agent to launch review tasks as parallel agents.
 3. The guidance MUST explain how to handle failing reviews (fix issues or call `mark_review_as_passed`).
 4. The guidance MUST instruct the agent to call `finished_step` again after reviews complete.
 

--- a/specs/deepwork/jobs/JOBS-REQ-014-deepplan.md
+++ b/specs/deepwork/jobs/JOBS-REQ-014-deepplan.md
@@ -39,7 +39,7 @@ DeepPlan is a standard job that provides a structured planning workflow. When an
 
 ### JOBS-REQ-014.5: Planning Mode Integration
 
-1. The startup context hook MUST inject an instruction telling agents to start the `create_deep_plan` workflow when entering plan mode.
+1. ~~DEPRECATED~~ ~~The startup context hook MUST inject an instruction telling agents to start the `create_deep_plan` workflow when entering plan mode.~~
 2. The `present_plan` step MUST instruct the agent to call `ExitPlanMode` instead of `finished_step`.
 3. The plan file MUST include execution instructions telling the post-approval agent to call `finished_step` on `present_plan` and then `start_workflow` on the session job.
 

--- a/specs/deepwork/jobs/JOBS-REQ-014-deepplan.md
+++ b/specs/deepwork/jobs/JOBS-REQ-014-deepplan.md
@@ -39,7 +39,7 @@ DeepPlan is a standard job that provides a structured planning workflow. When an
 
 ### JOBS-REQ-014.5: Planning Mode Integration
 
-1. ~~DEPRECATED~~ ~~The startup context hook MUST inject an instruction telling agents to start the `create_deep_plan` workflow when entering plan mode.~~
+1. REQUIREMENT REMOVED
 2. The `present_plan` step MUST instruct the agent to call `ExitPlanMode` instead of `finished_step`.
 3. The plan file MUST include execution instructions telling the post-approval agent to call `finished_step` on `present_plan` and then `start_workflow` on the session job.
 

--- a/specs/deepwork/review/REVIEW-REQ-006-cli-review-command.md
+++ b/specs/deepwork/review/REVIEW-REQ-006-cli-review-command.md
@@ -29,8 +29,8 @@ The `deepwork review` CLI command orchestrates the full DeepWork Reviews pipelin
 
 1. When `--instructions-for claude` is specified, the command MUST output to stdout a structured text block that Claude Code can use to dispatch parallel review agents.
 2. The output MUST begin with a line instructing the agent to invoke tasks in parallel.
-3. For each review task, the output MUST include fields matching the Claude Code `Task` tool parameters:
-   a. A `name` field formatted as `"{scope_prefix}{rule_name} review of {file_or_scope}"` — for `individual` strategy, `{file_or_scope}` is the single filename; for grouped strategies, it is a summary (e.g., `"3 files"`). When the rule comes from a `.deepreview` in a subdirectory, `{scope_prefix}` MUST be `"{parent_dir_name}/"` (e.g., `"my_job/"`); for root-level `.deepreview` files, `{scope_prefix}` MUST be empty.
+3. For each review task, the output MUST include fields matching the Claude Code `Agent` tool parameters:
+   a. ~~DEPRECATED~~ ~~A `name` field formatted as `"{scope_prefix}{rule_name} review of {file_or_scope}"`.~~
    b. A `description` field with a short (3-5 word) summary for the task (e.g., `"Review {rule_name}"`). When the rule comes from a `.deepreview` in a subdirectory, the description MUST include the scope (e.g., `"Review my_job/{rule_name}"`).
    c. A `subagent_type` field set to the agent persona name (from the rule's `agent.claude` value) or `"reviewer"` if no persona is specified. `"reviewer"` refers to the default reviewer subagent shipped by the DeepWork Claude plugin (`plugins/claude/agents/reviewer.md`).
    d. A `prompt` field referencing the instruction file path relative to the project root, prefixed with `@` (e.g., `@.deepwork/tmp/review_instructions/7142141.md`).

--- a/specs/learning-agents/LA-REQ-002-agent-creation.md
+++ b/specs/learning-agents/LA-REQ-002-agent-creation.md
@@ -70,7 +70,7 @@ The skill MUST offer the user the option to seed initial topics or learnings. If
 
 ### LA-REQ-002.14: Creation Summary
 
-Upon completion, the skill MUST output a summary listing all files created or modified, usage instructions for invoking the agent via the Task tool, and a note about the learning cycle.
+Upon completion, the skill MUST output a summary listing all files created or modified, usage instructions for invoking the agent via the Agent tool, and a note about the learning cycle.
 
 ### LA-REQ-002.15: No Overwrites Without Confirmation
 

--- a/specs/learning-agents/LA-REQ-004-session-tracking.md
+++ b/specs/learning-agents/LA-REQ-004-session-tracking.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-The learning-agents plugin uses hooks to automatically track when LearningAgents are invoked during Claude Code sessions. The PostToolUse hook on the Task tool creates session tracking files. The Stop hook checks for unprocessed sessions and suggests running the learning cycle.
+The learning-agents plugin uses hooks to automatically track when LearningAgents are invoked during Claude Code sessions. The PostToolUse hook on the Agent tool creates session tracking files. The Stop hook checks for unprocessed sessions and suggests running the learning cycle.
 
 ## Requirements
 
 ### LA-REQ-004.1: PostToolUse Hook Trigger
 
-The PostToolUse hook MUST fire after every use of the `Task` tool. The hook matcher in `hooks.json` MUST be set to `"Task"`.
+The PostToolUse hook MUST fire after every use of the `Agent` tool. The hook matcher in `hooks.json` MUST be set to `"Agent"`.
 
-### LA-REQ-004.2: Post-Task Input Parsing
+### LA-REQ-004.2: Post-Agent Input Parsing
 
 The `post_task.sh` hook MUST read JSON from stdin containing `session_id`, `tool_input`, and `tool_response` fields. If stdin is empty or not provided (terminal is interactive), the hook MUST output `{}` and exit 0.
 
@@ -42,11 +42,11 @@ The hook MUST create a `needs_learning_as_of_timestamp` file in the session dire
 
 The hook MUST create an `agent_used` file in the session directory containing the agent name (matching the folder name under `.deepwork/learning-agents/`). This links the session's agent ID back to the LearningAgent definition.
 
-### LA-REQ-004.10: Post-Task Reminder Message
+### LA-REQ-004.10: Post-Agent Reminder Message
 
 After creating session tracking files, the hook MUST output a JSON `systemMessage` containing the content of `${CLAUDE_PLUGIN_ROOT}/doc/learning_agent_post_task_reminder.md`. If the reminder file does not exist, the hook MUST output `{}`.
 
-### LA-REQ-004.11: Post-Task Reminder Content
+### LA-REQ-004.11: Post-Agent Reminder Content
 
 The post-task reminder MUST instruct the user to:
 - Resume the same task rather than starting a new one if they need more from the same agent

--- a/specs/learning-agents/LA-REQ-006-learning-cycle.md
+++ b/specs/learning-agents/LA-REQ-006-learning-cycle.md
@@ -31,7 +31,7 @@ For each pending session, the skill MUST run the learning cycle in three sequent
 2. **Investigate**: MUST spawn an Agent to run the `investigate-issues` skill on the session folder
 3. **Incorporate**: MUST spawn an Agent to run the `incorporate-learnings` skill on the session folder
 
-The investigate and incorporate phases MAY be combined into a single Agent invocation, but they MUST execute in that order.
+The investigate and incorporate phases MUST be combined into a single Agent invocation, and they MUST execute in that order.
 
 ### LA-REQ-006.6: Agent Tool Usage for Sub-Skills
 

--- a/specs/learning-agents/LA-REQ-006-learning-cycle.md
+++ b/specs/learning-agents/LA-REQ-006-learning-cycle.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The learning cycle (`/learning-agents learn`) is the top-level orchestrator that discovers all pending sessions and runs the three-phase learning process (identify, investigate, incorporate) on each. It delegates actual work to sub-skills via Task tool spawns.
+The learning cycle (`/learning-agents learn`) is the top-level orchestrator that discovers all pending sessions and runs the three-phase learning process (identify, investigate, incorporate) on each. It delegates actual work to sub-skills via Agent tool spawns.
 
 ## Requirements
 
@@ -27,19 +27,19 @@ For each pending session, the skill MUST extract:
 ### LA-REQ-006.5: Three-Phase Processing
 
 For each pending session, the skill MUST run the learning cycle in three sequential phases:
-1. **Identify**: Spawn a Task to run the `identify` skill on the session folder
-2. **Investigate**: Spawn a Task to run the `investigate-issues` skill on the session folder
-3. **Incorporate**: Spawn a Task to run the `incorporate-learnings` skill on the session folder
+1. **Identify**: MUST spawn an Agent to run the `identify` skill on the session folder
+2. **Investigate**: MUST spawn an Agent to run the `investigate-issues` skill on the session folder
+3. **Incorporate**: MUST spawn an Agent to run the `incorporate-learnings` skill on the session folder
 
-The investigate and incorporate phases MAY be combined into a single Task invocation, but they MUST execute in that order.
+The investigate and incorporate phases MAY be combined into a single Agent invocation, but they MUST execute in that order.
 
-### LA-REQ-006.6: Task Tool Usage for Sub-Skills
+### LA-REQ-006.6: Agent Tool Usage for Sub-Skills
 
-The identify phase MUST be run as a separate Task invocation. The investigate and incorporate phases MUST be run as a combined Task invocation (investigate first, then incorporate). All Task spawns MUST use the `learning-agents:identify`, `learning-agents:investigate-issues`, and `learning-agents:incorporate-learnings` skills respectively.
+The identify phase MUST be run as a separate Agent invocation. The investigate and incorporate phases MUST be run as a combined Agent invocation (investigate first, then incorporate). All Agent spawns MUST use the `learning-agents:identify`, `learning-agents:investigate-issues`, and `learning-agents:incorporate-learnings` skills respectively.
 
-### LA-REQ-006.7: Sub-Task Model Selection
+### LA-REQ-006.7: Sub-Agent Model Selection
 
-Task spawns for learning cycle sub-skills MUST use the Sonnet model to balance cost and quality.
+Agent spawns for learning cycle sub-skills MUST use the Sonnet model to balance cost and quality.
 
 ### LA-REQ-006.8: Sequential Session Processing
 

--- a/src/deepwork/hooks/README.md
+++ b/src/deepwork/hooks/README.md
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 | `grep` | Grep | grep |
 | `web_fetch` | WebFetch | web_fetch |
 | `web_search` | WebSearch | web_search |
-| `task` | Task | — |
+| `agent` | Agent | — |
 
 ## Decision Values
 

--- a/src/deepwork/hooks/wrapper.py
+++ b/src/deepwork/hooks/wrapper.py
@@ -121,7 +121,7 @@ TOOL_TO_NORMALIZED: dict[Platform, dict[str, str]] = {
         "Grep": "grep",
         "WebFetch": "web_fetch",
         "WebSearch": "web_search",
-        "Task": "task",
+        "Agent": "agent",
     },
     Platform.GEMINI: {
         # Gemini already uses snake_case
@@ -147,7 +147,7 @@ NORMALIZED_TO_TOOL: dict[Platform, dict[str, str]] = {
         "grep": "Grep",
         "web_fetch": "WebFetch",
         "web_search": "WebSearch",
-        "task": "Task",
+        "agent": "Agent",
     },
     Platform.GEMINI: {
         # Gemini already uses snake_case

--- a/src/deepwork/hooks/wrapper.py
+++ b/src/deepwork/hooks/wrapper.py
@@ -13,7 +13,8 @@ Normalized Format:
         - session_id: str
         - transcript_path: str
         - cwd: str
-        - event: str (normalized: 'after_agent', 'before_tool', 'before_prompt')
+        - event: str (normalized: 'after_agent', 'before_tool', 'before_prompt',
+          'session_start', 'session_end', 'after_tool', 'before_model', 'after_model')
         - tool_name: str (normalized: 'write_file', 'shell', etc.)
         - tool_input: dict
         - prompt: str (for agent events)

--- a/src/deepwork/jobs/job.schema.json
+++ b/src/deepwork/jobs/job.schema.json
@@ -141,7 +141,7 @@
         "agent": {
           "type": "string",
           "minLength": 1,
-          "description": "Agent type to delegate the entire workflow to (e.g., 'general-purpose'). When set, the workflow is designed to run in a sub-agent via the Task tool — the caller agent spawns a sub-agent that runs all steps. Use this for workflows that should execute autonomously without blocking the main agent. If not set, the main agent executes steps directly."
+          "description": "Agent type to delegate the entire workflow to (e.g., 'general-purpose'). When set, the workflow is designed to run in a sub-agent via the Agent tool — the caller agent spawns a sub-agent that runs all steps. Use this for workflows that should execute autonomously without blocking the main agent. If not set, the main agent executes steps directly."
         },
         "common_job_info_provided_to_all_steps_at_runtime": {
           "type": "string",

--- a/src/deepwork/jobs/mcp/quality_gate.py
+++ b/src/deepwork/jobs/mcp/quality_gate.py
@@ -32,12 +32,6 @@ from deepwork.utils.validation import ValidationError, validate_against_schema
 logger = logging.getLogger("deepwork.jobs.mcp.quality_gate")
 
 
-class QualityGateError(Exception):
-    """Exception raised for quality gate errors."""
-
-    pass
-
-
 def validate_json_schemas(
     outputs: dict[str, ArgumentValue],
     step: WorkflowStep,
@@ -275,10 +269,8 @@ Please review for compliance with the following requirements. You MUST fail the 
 
 Evaluate whether the work described in the `work_summary` meets each requirement. If an output file helps verify a requirement, read it."""
 
-        # Create a synthetic ReviewTask directly (not a ReviewRule since there are
-        # no file patterns to match — this is about the process, not files)
-        # We'll create a rule that matches all output files so it goes through
-        # the pipeline
+        # Create a ReviewRule that matches all output files so it goes through
+        # the standard review pipeline
         output_paths = _collect_output_file_paths(outputs, job)
         if output_paths:
             pqa_rule = ReviewRule(

--- a/src/deepwork/jobs/mcp/quality_gate.py
+++ b/src/deepwork/jobs/mcp/quality_gate.py
@@ -485,7 +485,7 @@ def _build_review_guidance(review_output: str) -> str:
 
 ## How to Run Reviews
 
-For each review task listed above, launch it as a parallel Task agent. The task's prompt field points to an instruction file — read it and follow the review instructions.
+For each review task listed above, launch it as a parallel Agent. The task's prompt field points to an instruction file — read it and follow the review instructions.
 
 ## After Reviews
 

--- a/src/deepwork/jobs/mcp/server.py
+++ b/src/deepwork/jobs/mcp/server.py
@@ -453,7 +453,7 @@ def create_server(
         description=(
             "Run a review of changed files based on .deepreview configuration files. "
             "Returns a list of review tasks to invoke in parallel. Each task has "
-            "name, description, subagent_type, and prompt fields for the Task tool. "
+            "description, subagent_type, and prompt fields for the Agent tool. "
             "Optional: files (list of file paths to review). When omitted, detects "
             "changes via git diff against the main branch."
         )

--- a/src/deepwork/jobs/mcp/tools.py
+++ b/src/deepwork/jobs/mcp/tools.py
@@ -112,14 +112,18 @@ class WorkflowTools:
             except Exception:
                 logger.warning("Failed to write session status", exc_info=True)
 
-    def _write_manifest(self) -> None:
+    def _write_manifest(self, jobs: list[JobDefinition] | None = None) -> None:
         """Write job manifest file if status_writer is configured.
+
+        Args:
+            jobs: Pre-loaded job list. When None, loads jobs from disk.
 
         Fire-and-forget: exceptions are logged as warnings and never propagated.
         """
         if self.status_writer:
             try:
-                jobs, _ = self._load_all_jobs()
+                if jobs is None:
+                    jobs, _ = self._load_all_jobs()
                 self.status_writer.write_manifest(jobs)
             except Exception:
                 logger.warning("Failed to write job manifest", exc_info=True)
@@ -265,6 +269,9 @@ class WorkflowTools:
                 continue
 
             if arg.type == "file_path":
+                # Deliberate: no path-traversal check here. Outputs come from
+                # the agent (not untrusted external input) and may legitimately
+                # reference paths outside the project root (e.g. worktrees).
                 if isinstance(value, str):
                     full_path = self.project_root / value
                     if not full_path.exists():
@@ -437,11 +444,7 @@ class WorkflowTools:
         ]
 
         # Write manifest for external consumers
-        if self.status_writer:
-            try:
-                self.status_writer.write_manifest(jobs)
-            except Exception:
-                logger.warning("Failed to write job manifest", exc_info=True)
+        self._write_manifest(jobs)
 
         return GetWorkflowsResponse(jobs=job_infos, errors=error_infos)
 

--- a/src/deepwork/jobs/mcp/tools.py
+++ b/src/deepwork/jobs/mcp/tools.py
@@ -134,11 +134,11 @@ class WorkflowTools:
         for wf_name, wf in job.workflows.items():
             if wf.agent:
                 how_to_invoke = (
-                    f'Invoke as a Task using subagent_type="{wf.agent}" with a prompt '
+                    f'Invoke as an Agent using subagent_type="{wf.agent}" with a prompt '
                     f"giving full context needed and instructions to call "
                     f"`mcp__plugin_deepwork_deepwork__start_workflow` "
                     f'(job_name="{job.name}", workflow_name="{wf_name}"). '
-                    f"If you do not have Task as an available tool, invoke the workflow directly."
+                    f"If you do not have Agent as an available tool, invoke the workflow directly."
                 )
             else:
                 how_to_invoke = (

--- a/src/deepwork/review/formatter.py
+++ b/src/deepwork/review/formatter.py
@@ -90,7 +90,7 @@ def format_for_claude(
     file_ref_root = _resolve_file_ref_root(project_root)
 
     lines: list[str] = []
-    lines.append("Invoke the following list of Tasks in parallel.")
+    lines.append("Invoke the following list of Agents in parallel.")
     lines.append(
         "IMPORTANT: Do NOT read the prompt files yourself. Pass the prompt field "
         "directly to each agent — the @file references are expanded automatically.\n"
@@ -104,12 +104,10 @@ def format_for_claude(
         except ValueError:
             rel_path = file_path
 
-        name = _task_name(task)
         description = _task_description(task)
         subagent_type = task.agent_name or "reviewer"
 
-        lines.append(f'name: "{name}"')
-        lines.append(f"\tdescription: {description}")
+        lines.append(f"description: {description}")
         lines.append(f"\tsubagent_type: {subagent_type}")
         lines.append(f'\tprompt: "@{rel_path}"')
         lines.append("")
@@ -129,29 +127,6 @@ def _task_description(task: ReviewTask) -> str:
     prefix = _scope_prefix(task)
     return f"Review {prefix}{task.rule_name}"
 
-
-def _task_name(task: ReviewTask) -> str:
-    """Generate a descriptive name for a review task.
-
-    Includes a scope prefix derived from the source directory when the
-    rule comes from a subdirectory .deepreview file.  This disambiguates
-    same-named rules from different directories (REVIEW-REQ-004.10).
-
-    For inline-content tasks (type: string step outputs per JOBS-REQ-004.8)
-    the scope reads ``inline content`` instead of a file count.
-
-    Args:
-        task: The ReviewTask to name.
-
-    Returns:
-        Task name string.
-    """
-    prefix = _scope_prefix(task)
-    if not task.files_to_review and task.inline_content is not None:
-        return f"{prefix}{task.rule_name} review of inline content"
-    if len(task.files_to_review) == 1:
-        return f"{prefix}{task.rule_name} review of {task.files_to_review[0]}"
-    return f"{prefix}{task.rule_name} review of {len(task.files_to_review)} files"
 
 
 def _scope_prefix(task: ReviewTask) -> str:

--- a/src/deepwork/review/formatter.py
+++ b/src/deepwork/review/formatter.py
@@ -128,7 +128,6 @@ def _task_description(task: ReviewTask) -> str:
     return f"Review {prefix}{task.rule_name}"
 
 
-
 def _scope_prefix(task: ReviewTask) -> str:
     """Derive a short scope prefix from the task's source_location.
 

--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -69,6 +69,10 @@ step_arguments:
     description: "List of job.yml file paths available via the configured library path"
     type: file_path
 
+  - name: errata_summary
+    description: "Summary of obsolete artifacts removed during cleanup."
+    type: string
+
 workflows:
   new_job:
     summary: "Create a new DeepWork job from scratch through definition, implementation, testing, and iteration"
@@ -915,7 +919,7 @@ workflows:
 
           1. **Process Inefficiencies**
              - Steps that took multiple attempts to complete
-             - Questions the agent had to ask that should have been necessary
+             - Questions the agent had to ask that shouldn't have been necessary
              - Unnecessary back-and-forth with the user
              - Information that had to be repeated
 
@@ -1483,9 +1487,9 @@ workflows:
             required: true
         process_requirements:
           "New Format Used": "All job.yml files MUST use the new format with step_arguments, workflows{} object, and inline step instructions."
-          "No Legacy Fields": "No job.yml MUST contain version, root-level steps[], instructions_file, hooks, dependencies, or exposed/hidden fields."
+          "No Legacy Fields": "No job.yml MAY contain version, root-level steps[], instructions_file, hooks, dependencies, or exposed/hidden fields."
           "Reviews Migrated": "Old review formats MUST be converted to output-level review blocks or process_requirements."
-          "Instructions Inlined": "All step instructions MUST be inlined in the job.yml — no instructions_file references MUST remain."
+          "Instructions Inlined": "All step instructions MUST be inlined in the job.yml — no instructions_file references MAY remain."
           "Orphaned Step Files Removed": "Step .md files that were referenced by `instructions_file` and have been inlined MUST be deleted from the steps/ directory."
           "Jobs Parse Successfully": "Calling `get_workflows` MUST show all expected jobs without errors."
 
@@ -1670,7 +1674,9 @@ workflows:
         inputs:
           job_definitions:
             required: true
-        outputs: {}
+        outputs:
+          errata_summary:
+            required: true
         process_requirements:
           "Legacy Job Skills Removed": "Legacy skill folders for each job MUST be removed from `.claude/skills/` and `.gemini/skills/`."
           "Deepwork Skill Removed": "The `deepwork` skill folder MUST be removed from `.claude/skills/deepwork/` and `.gemini/skills/deepwork/` (now provided by the plugin system)."

--- a/src/deepwork/standard_jobs/deepwork_jobs/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_jobs/job.yml
@@ -195,7 +195,7 @@ workflows:
 
           1. **Define a separate workflow** for the process that will be repeated. This workflow handles one item at a time (e.g., `research_one_competitor` with steps like `gather_data` → `analyze` → `write_summary`).
 
-          2. **In the main workflow**, add a step whose instructions tell the agent to launch the sub-workflow once per item using sub-agents (via the Task tool). Since each item is independent, these sub-workflow runs execute in parallel.
+          2. **In the main workflow**, add a step whose instructions tell the agent to launch the sub-workflow once per item using sub-agents (via the Agent tool). Since each item is independent, these sub-workflow runs execute in parallel.
 
           **Why this matters:**
           - **Parallelism**: Independent items are processed concurrently instead of sequentially, dramatically reducing wall-clock time
@@ -229,7 +229,7 @@ workflows:
 
           The `research_all` step's instructions should tell the agent to:
           - Read the list of items from the prior step's output
-          - Launch `research_one` as a sub-workflow for each item using parallel sub-agents (Task tool)
+          - Launch `research_one` as a sub-workflow for each item using parallel sub-agents (Agent tool)
           - Collect the results and confirm all runs completed
 
           **When to recognize this pattern:** Look for language like "for each X, do Y" where Y involves more than one logical phase. If Y is a single simple action, a regular step with a loop is fine. If Y is itself a multi-step process with intermediate outputs worth reviewing, split it into a sub-workflow.

--- a/src/deepwork/standard_jobs/deepwork_reviews/job.yml
+++ b/src/deepwork/standard_jobs/deepwork_reviews/job.yml
@@ -284,7 +284,7 @@ workflows:
 
           For each unprotected documentation file, call `start_workflow` directly with `job_name: "deepwork_reviews"`, `workflow_name: "add_document_update_rule"`, and the doc path (relative to the repository root, e.g., `doc/architecture.md`) as the goal. Complete each nested workflow's steps (analyze_dependencies, apply_rule) before starting the next.
 
-          **Note**: Nested workflows are session-scoped MCP calls — do not attempt to run them inside separate Task agents, as MCP session context would not be shared. Run them sequentially from this agent.
+          **Note**: Nested workflows are session-scoped MCP calls — do not attempt to run them inside separate sub-agents, as MCP session context would not be shared. Run them sequentially from this agent.
 
           ### 4. Review the resulting rules for scope efficiency
 
@@ -372,7 +372,7 @@ workflows:
 
           #### c. Extract conventions from existing code
 
-          If the above sources don't provide enough conventions, launch an Explore agent (via a separate Task, one per language) to examine existing code files and extract observable patterns. The agent prompt should ask it to examine 10-20 representative files and return a bulleted list of observed patterns covering:
+          If the above sources don't provide enough conventions, launch an Explore agent (via a separate Agent, one per language) to examine existing code files and extract observable patterns. The agent prompt should ask it to examine 10-20 representative files and return a bulleted list of observed patterns covering:
 
           - Naming conventions (camelCase vs snake_case, prefixes, suffixes)
           - Import ordering and grouping

--- a/src/deepwork/standard_schemas/requirements_file/deepschema.yml
+++ b/src/deepwork/standard_schemas/requirements_file/deepschema.yml
@@ -71,7 +71,7 @@ requirements:
     all other IDs remain stable and external references do not break.
 
 verification_bash_command:
-  - "grep -nE '^[0-9]+\\.' \"$1\" | grep -vE 'MUST|SHALL|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL' | { if read -r line; then echo \"FAIL: Requirement without RFC 2119 keyword: $line\"; exit 1; fi; }"
+  - "grep -nE '^[0-9]+\\.' \"$1\" | grep -vE 'MUST|SHALL|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL|REQUIREMENT REMOVED' | { if read -r line; then echo \"FAIL: Requirement without RFC 2119 keyword: $line\"; exit 1; fi; }"
 
 references:
   - path: "https://www.ietf.org/rfc/rfc2119.txt"

--- a/tests/unit/jobs/mcp/test_schemas.py
+++ b/tests/unit/jobs/mcp/test_schemas.py
@@ -46,11 +46,11 @@ class TestWorkflowInfo:
         workflow = WorkflowInfo(
             name="test_workflow",
             summary="A test workflow",
-            how_to_invoke='Invoke as a Task using subagent_type="general-purpose"',
+            how_to_invoke='Invoke as an Agent using subagent_type="general-purpose"',
         )
 
         assert "general-purpose" in workflow.how_to_invoke
-        assert "Task" in workflow.how_to_invoke
+        assert "Agent" in workflow.how_to_invoke
 
 
 class TestJobInfo:

--- a/tests/unit/jobs/test_deepplan.py
+++ b/tests/unit/jobs/test_deepplan.py
@@ -94,24 +94,13 @@ class TestDeepplanJobDefinition:
 
 
 class TestDeepplanStartupHook:
-    """Validate the startup context hook injects DeepPlan trigger."""
-
-    # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-014.5.1).
-    # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-    def test_startup_hook_contains_deepplan_trigger(self) -> None:
-        """startup_context.sh injects an instruction to start create_deep_plan."""
-        content = _STARTUP_HOOK.read_text(encoding="utf-8")
-        assert "create_deep_plan" in content
-        assert "deepplan" in content
-        assert "start_workflow" in content
+    """Validate the startup context hook basics."""
 
     @pytest.mark.skipif(
         not _STARTUP_HOOK.exists(),
         reason="startup_context.sh not found",
     )
     def test_startup_hook_is_executable(self) -> None:
-        # THIS TEST VALIDATES A HARD REQUIREMENT (JOBS-REQ-014.5.1).
-        # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
         """startup_context.sh has execute permission."""
         import os
 

--- a/tests/unit/review/test_formatter.py
+++ b/tests/unit/review/test_formatter.py
@@ -38,37 +38,7 @@ class TestFormatForClaude:
         file_path.parent.mkdir(parents=True)
         file_path.write_text("content")
         result = format_for_claude([(task, file_path)], tmp_path)
-        assert result.startswith("Invoke the following list of Tasks in parallel.")
-
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a).
-    # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-    def test_individual_task_name_includes_filename(self, tmp_path: Path) -> None:
-        task = _make_task(rule_name="py_review", files=["src/app.py"])
-        file_path = tmp_path / "instructions.md"
-        result = format_for_claude([(task, file_path)], tmp_path)
-        assert 'name: "py_review review of src/app.py"' in result
-
-    # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a).
-    # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
-    def test_grouped_task_name_includes_file_count(self, tmp_path: Path) -> None:
-        task = _make_task(rule_name="py_review", files=["a.py", "b.py", "c.py"])
-        file_path = tmp_path / "instructions.md"
-        result = format_for_claude([(task, file_path)], tmp_path)
-        assert 'name: "py_review review of 3 files"' in result
-
-    def test_inline_content_task_name_says_inline_content(self, tmp_path: Path) -> None:
-        """Inline-content tasks render as "review of inline content", not "0 files"."""
-        task = ReviewTask(
-            rule_name="string_rule",
-            files_to_review=[],
-            instructions="Review the value.",
-            agent_name=None,
-            inline_content="the value",
-        )
-        file_path = tmp_path / "instructions.md"
-        result = format_for_claude([(task, file_path)], tmp_path)
-        assert 'name: "string_rule review of inline content"' in result
-        assert "0 files" not in result
+        assert result.startswith("Invoke the following list of Agents in parallel.")
 
     # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3c).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
@@ -110,18 +80,17 @@ class TestFormatForClaude:
         file_a = tmp_path / "a.md"
         file_b = tmp_path / "b.md"
         result = format_for_claude([(task_a, file_a), (task_b, file_b)], tmp_path)
-        assert 'name: "rule_a review of a.py"' in result
-        assert 'name: "rule_b review of b.py"' in result
+        assert "description: Review rule_a" in result
+        assert "description: Review rule_b" in result
 
     # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a, REVIEW-REQ-004.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_scope_prefix_from_subdirectory_source(self, tmp_path: Path) -> None:
-        """Rules from subdirectory .deepreview files include scope prefix in name."""
+        """Rules from subdirectory .deepreview files include scope prefix in description."""
         task = _make_task(rule_name="job_definition_review", files=["job.yml"])
         task.source_location = "jobs/my_job/.deepreview:1"
         file_path = tmp_path / "instructions.md"
         result = format_for_claude([(task, file_path)], tmp_path)
-        assert 'name: "my_job/job_definition_review review of job.yml"' in result
         assert "description: Review my_job/job_definition_review" in result
 
     # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a, REVIEW-REQ-004.10).
@@ -132,13 +101,12 @@ class TestFormatForClaude:
         task.source_location = ".deepreview:5"
         file_path = tmp_path / "instructions.md"
         result = format_for_claude([(task, file_path)], tmp_path)
-        assert 'name: "py_review review of app.py"' in result
         assert "description: Review py_review" in result
 
     # THIS TEST VALIDATES A HARD REQUIREMENT (REVIEW-REQ-006.3.3a, REVIEW-REQ-004.10).
     # YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES
     def test_same_name_rules_disambiguated_by_scope(self, tmp_path: Path) -> None:
-        """Same-named rules from different directories produce distinct names."""
+        """Same-named rules from different directories produce distinct descriptions."""
         task_a = _make_task(rule_name="job_definition_review", files=["a/job.yml"])
         task_a.source_location = "jobs/job_a/.deepreview:1"
         task_b = _make_task(rule_name="job_definition_review", files=["b/job.yml"])
@@ -146,8 +114,8 @@ class TestFormatForClaude:
         file_a = tmp_path / "a.md"
         file_b = tmp_path / "b.md"
         result = format_for_claude([(task_a, file_a), (task_b, file_b)], tmp_path)
-        assert 'name: "job_a/job_definition_review review of a/job.yml"' in result
-        assert 'name: "job_b/job_definition_review review of b/job.yml"' in result
+        assert "description: Review job_a/job_definition_review" in result
+        assert "description: Review job_b/job_definition_review" in result
 
 
 class TestGitCommonDir:

--- a/tests/unit/test_learning_agents_session_tracking.py
+++ b/tests/unit/test_learning_agents_session_tracking.py
@@ -133,7 +133,7 @@ class TestPostToolUseHookTrigger:
 
 
 # ===========================================================================
-# LA-REQ-004.2: Post-Task Input Parsing
+# LA-REQ-004.2: Post-Agent Input Parsing
 # ===========================================================================
 
 
@@ -433,7 +433,7 @@ class TestAgentUsedFile:
 
 
 # ===========================================================================
-# LA-REQ-004.10: Post-Task Reminder Message
+# LA-REQ-004.10: Post-Agent Reminder Message
 # ===========================================================================
 
 
@@ -483,7 +483,7 @@ class TestPostTaskReminderMessage:
 
 
 # ===========================================================================
-# LA-REQ-004.11: Post-Task Reminder Content
+# LA-REQ-004.11: Post-Agent Reminder Content
 # ===========================================================================
 
 


### PR DESCRIPTION
## Summary
- Removed the startup_context.sh hook injection that forced agents into the DeepPlan workflow when entering plan mode
- Renamed all "Task tool" references to "Agent tool" across the entire codebase (source, tests, specs, docs, skills, schemas, hooks) to match Claude Code's current tool naming
- Review formatter now emits `description`, `subagent_type`, and `prompt` fields (dropped `name` field) to match Agent tool signature
- Hook wrapper tool mappings updated: `Task`/`task` → `Agent`/`agent`
- Deprecated JOBS-REQ-014.5.1 and REVIEW-REQ-006.3.3a
- Added `agents/` directory to AGENTS.md project structure
- Fixed pre-existing review findings: dead code, stale comments, doc/spec inaccuracies, RFC 2119 phrasing errors

## Test plan
- [x] `pytest` — 1289 passed, 1 skipped, 1 xfailed
- [x] Review formatter output verified via dev MCP — correct format with no `name` field
- [x] 48 review agents run — all findings addressed
- [ ] Verify startup hook still injects session/agent IDs correctly
- [ ] Verify entering plan mode no longer auto-triggers DeepPlan

🤖 Generated with [Claude Code](https://claude.com/claude-code)