### PR TITLE
fix: add Monitor permission and auto defaultMode to settings schema

### DIFF
--- a/library/jobs/.deepreview
+++ b/library/jobs/.deepreview
@@ -51,7 +51,7 @@ library_job_portability:
         (e.g., `.repos/acme/api/` or `/code/myproject/`)
 
       Acceptable: relative paths within the job directory (e.g., `templates/bar.yml`,
-      `templates/bar.yml`) and generic placeholders like `<project_root>`.
+      `conventions.md`) and generic placeholders like `<project_root>`.
 
       ## Personal and Private Information
 

--- a/src/deepwork/standard_schemas/claude_settings/claude_settings.schema.json
+++ b/src/deepwork/standard_schemas/claude_settings/claude_settings.schema.json
@@ -1,12 +1,12 @@
 {
-  "_source": "Vendored from https://json.schemastore.org/claude-code-settings.json (SchemaStore community project). To update: fetch the latest version from that URL and replace this file. Last synced: 2026-04-01.",
+  "_source": "Vendored from https://json.schemastore.org/claude-code-settings.json (SchemaStore community project). To update: fetch the latest version from that URL and replace this file. Last synced: 2026-04-13.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/claude-code-settings.json",
   "$defs": {
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|NotebookEdit|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|NotebookEdit|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -360,13 +360,14 @@
           "type": "string",
           "enum": [
             "acceptEdits",
+            "auto",
             "bypassPermissions",
             "default",
             "delegate",
             "dontAsk",
             "plan"
           ],
-          "description": "Default permission mode.\n\"default\": prompts on first use.\n\"acceptEdits\": auto-accepts file edits.\n\"plan\": read-only, no modifications.\nUNDOCUMENTED. \"delegate\": coordination-only for agent team leads (agent teams are experimental; enable via CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).\n\"dontAsk\": auto-denies unless pre-approved via permissions.\n\"bypassPermissions\": skips all prompts (use only in isolated environments).\nSee https://code.claude.com/docs/en/permissions"
+          "description": "Default permission mode.\n\"default\": prompts on first use.\n\"acceptEdits\": auto-accepts file edits.\n\"plan\": read-only, no modifications.\nUNDOCUMENTED. \"delegate\": coordination-only for agent team leads (agent teams are experimental; enable via CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).\n\"dontAsk\": auto-denies unless pre-approved via permissions.\n\"bypassPermissions\": skips all prompts (use only in isolated environments).\n\"auto\": auto-approves tool calls with background safety checks that verify actions align with your request.\nSee https://code.claude.com/docs/en/permissions"
         },
         "disableBypassPermissionsMode": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Added `Monitor` to the `permissionRule` pattern — it's now a valid tool permission type for streaming events from background scripts
- Added `"auto"` to the `defaultMode` enum with description — auto-approves tool calls with background safety checks
- Updated vendored schema sync date to 2026-04-13

## Test plan
- [x] JSON schema validates (`python3 -c "import json; json.load(open(...))"`)
- [ ] Verify `Monitor` permission rules are accepted by Claude Code settings validation
- [ ] Verify `"auto"` defaultMode is accepted without schema warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)