### PR TITLE
fix: remove redundant plugin prefix from reviewer agent name

### DIFF
--- a/plugins/claude/agents/reviewer.md
+++ b/plugins/claude/agents/reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: deepwork:reviewer
+name: reviewer
 description: Minimal review subagent for DeepWork review tasks. Reads a supplied instruction file, performs the review against the criteria in that file, and reports results via the DeepWork MCP mark_review_as_passed tool. Use when dispatching parallel review tasks from .deepreview rules or workflow quality gates.
 model: sonnet
 color: cyan


### PR DESCRIPTION
## Summary
- The reviewer agent name was `deepwork:reviewer`, but the platform auto-prefixes the plugin name, resulting in `deepwork:deepwork:reviewer`
- Renamed to just `reviewer` so it resolves correctly as `deepwork:reviewer`

## Test plan
- [ ] Verify the agent is invoked as `deepwork:reviewer` (not `deepwork:deepwork:reviewer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)