### PR TITLE
fix: shared_jobs sparse checkout excludes nix flake files

### DIFF
--- a/src/deepwork/standard_jobs/deepwork_jobs/sync_shared_jobs.md
+++ b/src/deepwork/standard_jobs/deepwork_jobs/sync_shared_jobs.md
@@ -82,10 +82,11 @@ If the user selects "Custom local path", ask for the filesystem path to the Deep
 
 1. If `.deepwork/upstream/` doesn't exist, create it:
    ```bash
-   git clone --sparse --filter=blob:none \
+   git clone --no-checkout --filter=blob:none \
      https://github.com/Unsupervisedcom/deepwork.git \
      .deepwork/upstream
-   git -C .deepwork/upstream sparse-checkout set --cone library/jobs/
+   git -C .deepwork/upstream sparse-checkout set --no-cone 'library/jobs/**'
+   git -C .deepwork/upstream checkout
    ```
 2. If it already exists, update it:
    ```bash
@@ -124,10 +125,11 @@ The env var must be set so the DeepWork plugin discovers library jobs at runtime
      ```bash
      REPO_ROOT="$(git rev-parse --show-toplevel)"
      if [ ! -d "$REPO_ROOT/.deepwork/upstream" ]; then
-       git clone --sparse --filter=blob:none \
+       git clone --no-checkout --filter=blob:none \
          https://github.com/Unsupervisedcom/deepwork.git \
          "$REPO_ROOT/.deepwork/upstream"
-       git -C "$REPO_ROOT/.deepwork/upstream" sparse-checkout set --cone library/jobs/
+       git -C "$REPO_ROOT/.deepwork/upstream" sparse-checkout set --no-cone 'library/jobs/**'
+       git -C "$REPO_ROOT/.deepwork/upstream" checkout
      else
        git -C "$REPO_ROOT/.deepwork/upstream" pull --ff-only
      fi


### PR DESCRIPTION
## Summary
- Switches the `sync_shared_jobs` sparse clone from `--sparse --cone` to `--no-checkout --no-cone` mode
- Ensures only `library/jobs/**` is checked out, preventing root-level files (flake.nix, flake.lock) from being materialized
- Applies the fix to both clone locations in the step instructions

## Test plan
- [ ] Run the shared_jobs workflow in a test repo and verify `.deepwork/upstream/` contains only `library/jobs/` contents
- [ ] Verify no `flake.nix` or `flake.lock` appears in the sparse checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)