### PR TITLE
README: source-available, not open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ One user used DeepWork to automatically research email performance across hundre
 | **Engineers** | Standup summaries, code review, release notes |
 | **Data/Analytics** | Multi-source data pulls, ETL, custom reports and dashboards |
 
-DeepWork is a free, open-source tool — if you're already paying for a Claude Max subscription, each of these automations costs you nothing additional.
+DeepWork is free to use (source available under BSL 1.1) — if you're already paying for a Claude Max subscription, each of these automations costs you nothing additional.
 
 Similar to how vibe coding makes it easier for anyone to produce software, this is **vibe automation**: describe what you want, let it run, and then iterate on what works.
 


### PR DESCRIPTION
One line: the README called DeepWork "a free, open-source tool", but the license is BSL 1.1 (source-available). Now reads "free to use (source available under BSL 1.1)", matching the Source available label on unsupervised.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eX855AM81mKyj2bM1dBp1